### PR TITLE
Добавить отдельное окно подбора стратегий и обновить диагностику

### DIFF
--- a/FluxRoute.Core/Models/ProfileProbeOptions.cs
+++ b/FluxRoute.Core/Models/ProfileProbeOptions.cs
@@ -23,5 +23,8 @@ public sealed class ProfileProbeOptions
     /// <summary>Сколько целей проверять параллельно. Не ставь слишком много: каждый HTTP-тест запускает curl.exe.</summary>
     public int MaxParallelChecks { get; init; } = 6;
 
+    /// <summary>Получает результат каждой цели сразу после её завершения.</summary>
+    public IProgress<CheckResult>? CheckProgress { get; init; }
+
     public string ProcessName { get; init; } = "winws";
 }

--- a/FluxRoute.Core/Services/ConnectivityChecker.cs
+++ b/FluxRoute.Core/Services/ConnectivityChecker.cs
@@ -28,7 +28,8 @@ public interface IConnectivityChecker
         IEnumerable<TargetEntry> targets,
         bool useCurlForHttp,
         int maxParallelChecks,
-        CancellationToken ct = default);
+        CancellationToken ct = default,
+        IProgress<CheckResult>? progress = null);
 }
 
 public sealed class ConnectivityChecker : IConnectivityChecker
@@ -127,7 +128,8 @@ public sealed class ConnectivityChecker : IConnectivityChecker
         IEnumerable<TargetEntry> targets,
         bool useCurlForHttp,
         int maxParallelChecks,
-        CancellationToken ct = default)
+        CancellationToken ct = default,
+        IProgress<CheckResult>? progress = null)
     {
         var targetList = targets
             .Where(x => !string.IsNullOrWhiteSpace(x.Value))
@@ -146,7 +148,9 @@ public sealed class ConnectivityChecker : IConnectivityChecker
             await throttler.WaitAsync(ct).ConfigureAwait(false);
             try
             {
-                return await CheckAsync(target, useCurlForHttp, ct).ConfigureAwait(false);
+                var result = await CheckAsync(target, useCurlForHttp, ct).ConfigureAwait(false);
+                progress?.Report(result);
+                return result;
             }
             finally
             {

--- a/FluxRoute.Core/Services/OrchestratorService.cs
+++ b/FluxRoute.Core/Services/OrchestratorService.cs
@@ -77,9 +77,10 @@ public sealed class OrchestratorService : IDisposable
 
     public async Task ScanAllProfilesAsync(
         CancellationToken ct = default,
-        IProgress<(int current, int total)>? progress = null)
+        IProgress<(int current, int total)>? progress = null,
+        IProgress<CheckResult>? checkProgress = null)
     {
-        await ScanAndRankAsync(ct, progress).ConfigureAwait(false);
+        await ScanAndRankAsync(ct, progress, checkProgress).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -138,7 +139,8 @@ public sealed class OrchestratorService : IDisposable
 
     private async Task ScanAndRankAsync(
         CancellationToken ct,
-        IProgress<(int current, int total)>? progress = null)
+        IProgress<(int current, int total)>? progress = null,
+        IProgress<CheckResult>? checkProgress = null)
     {
         if (IsScanning)
         {
@@ -175,7 +177,11 @@ public sealed class OrchestratorService : IDisposable
                 var result = await _probeService.ProbeAsync(
                     profile,
                     targets,
-                    new ProfileProbeOptions { StopAfterProbe = true },
+                    new ProfileProbeOptions
+                    {
+                        StopAfterProbe = true,
+                        CheckProgress = checkProgress
+                    },
                     ct).ConfigureAwait(false);
 
                 scores.Add((profile, result.Score, result));
@@ -304,6 +310,8 @@ public sealed class OrchestratorService : IDisposable
         await _switchProfile(null).ConfigureAwait(false);
         Notify("❌ Ни одна стратегия не прошёла проверку.");
     }
+
+    public IReadOnlyList<TargetEntry> GetScanTargets() => BuildTargets();
 
     private List<TargetEntry> BuildTargets()
     {

--- a/FluxRoute.Core/Services/ProfileProbeService.cs
+++ b/FluxRoute.Core/Services/ProfileProbeService.cs
@@ -106,7 +106,8 @@ public sealed class ProfileProbeService
             targetList,
             options.UseCurlForHttp,
             options.MaxParallelChecks,
-            ct).ConfigureAwait(false);
+            ct,
+            options.CheckProgress).ConfigureAwait(false);
         var score = ProfileScoringService.Calculate(processStarted, processStable, checks, options.RequireWinwsProcess);
 
         sw.Stop();

--- a/FluxRoute/Controls/ScanProgressView.xaml
+++ b/FluxRoute/Controls/ScanProgressView.xaml
@@ -1,24 +1,196 @@
 <UserControl x:Class="FluxRoute.Controls.ScanProgressView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <StackPanel>
-        <TextBlock FontFamily="Segoe UI" FontSize="11" Foreground="#8B949E"
-                   TextWrapping="Wrap" Margin="0,0,0,12"
-                   Text="Проверка всех стратегий на доступность целей и стабильность winws.exe." />
-        <TextBlock FontFamily="Segoe UI" FontSize="12" Foreground="#C9D1D9"
-                   Text="{Binding ScanStatusText}" Margin="0,0,0,8" />
-        <ProgressBar Value="{Binding ScanProgressValue}" Minimum="0" Maximum="100"
-                     Height="6" Background="#21262D" Foreground="#58A6FF"
-                     BorderThickness="0" Margin="0,0,0,4" />
-        <TextBlock FontFamily="Segoe UI" FontSize="11" Foreground="#8B949E"
-                   Text="{Binding ScanProgressValue, StringFormat={}{0:0}%}"
-                   Margin="0,0,0,8" />
-        <TextBlock FontFamily="Segoe UI" FontSize="11" Foreground="#4A5170"
-                   Text="{Binding ScanTimeRemaining}" Margin="0,0,0,2" />
-        <TextBlock FontFamily="Segoe UI" FontSize="11" Foreground="#4A5170"
-                   Text="{Binding ScanElapsed}" Margin="0,0,0,12" />
-        <Button Content="Отмена" Style="{StaticResource ActionBtnRed}"
-                HorizontalAlignment="Left" Padding="14,7"
-                Command="{Binding CancelScanCommand}" />
-    </StackPanel>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" FontFamily="Segoe UI" FontSize="12" Foreground="#8B949E"
+                   TextWrapping="Wrap" Margin="0,0,0,10"
+                   Text="Слева — проверка целей текущей стратегии. Справа — стратегии, которые уже прошли проверку." />
+
+        <Border Grid.Row="1" Background="#0E1624" BorderBrush="#253553" BorderThickness="1"
+                CornerRadius="8" Padding="10,8" Margin="0,0,0,8">
+            <Grid>
+                <StackPanel>
+                    <TextBlock Text="ТЕКУЩАЯ СТРАТЕГИЯ" FontFamily="Segoe UI" FontSize="10"
+                               FontWeight="SemiBold" Foreground="#66758E" />
+                    <TextBlock Text="{Binding ScanCurrentStrategy}" FontFamily="Segoe UI" FontSize="12"
+                               FontWeight="SemiBold" Foreground="#DCE4F0"
+                               TextTrimming="CharacterEllipsis" Margin="0,3,0,0" />
+                </StackPanel>
+                <StackPanel HorizontalAlignment="Right">
+                    <TextBlock Text="ЦЕЛИ ПРОВЕРКИ" FontFamily="Segoe UI" FontSize="10"
+                               FontWeight="SemiBold" Foreground="#66758E"
+                               HorizontalAlignment="Right" />
+                    <TextBlock Text="{Binding ScanTargetsText}" FontFamily="Segoe UI" FontSize="11"
+                               Foreground="#AFC1E3" TextTrimming="CharacterEllipsis"
+                               HorizontalAlignment="Right" Margin="0,3,0,0" />
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <Border Grid.Row="2" Background="#0E1120" BorderBrush="#1E2235" BorderThickness="1"
+                CornerRadius="8" Padding="10,9" Margin="0,0,0,10">
+            <StackPanel>
+                <Grid Margin="0,0,0,5">
+                    <TextBlock Text="{Binding ScanStatusText}" FontFamily="Segoe UI" FontSize="12"
+                               Foreground="#C8D4EC" />
+                    <TextBlock Text="{Binding ScanProgressValue, StringFormat={}{0:0}%}"
+                               HorizontalAlignment="Right" FontFamily="Segoe UI" FontSize="12"
+                               FontWeight="SemiBold" Foreground="#58A6FF" />
+                </Grid>
+                <ProgressBar Value="{Binding ScanProgressValue}" Minimum="0" Maximum="100"
+                             Height="6" Background="#21262D" Foreground="#58A6FF"
+                             BorderThickness="0">
+                    <ProgressBar.Template>
+                        <ControlTemplate TargetType="ProgressBar">
+                            <Border Background="{TemplateBinding Background}" CornerRadius="3">
+                                <Grid>
+                                    <Border x:Name="PART_Track" />
+                                    <Border x:Name="PART_Indicator" CornerRadius="3"
+                                            HorizontalAlignment="Left">
+                                        <Border.Background>
+                                            <LinearGradientBrush StartPoint="0,0" EndPoint="1,0">
+                                                <GradientStop Color="#58A6FF" Offset="0" />
+                                                <GradientStop Color="#9966FF" Offset="1" />
+                                            </LinearGradientBrush>
+                                        </Border.Background>
+                                    </Border>
+                                </Grid>
+                            </Border>
+                        </ControlTemplate>
+                    </ProgressBar.Template>
+                </ProgressBar>
+                <Grid Margin="0,6,0,0">
+                    <TextBlock Text="{Binding ScanTimeRemaining}" FontFamily="Segoe UI" FontSize="11"
+                               Foreground="#66758E" />
+                    <TextBlock Text="{Binding ScanElapsed}" HorizontalAlignment="Right"
+                               FontFamily="Segoe UI" FontSize="11" Foreground="#66758E" />
+                </Grid>
+            </StackPanel>
+        </Border>
+
+        <Grid Grid.Row="3">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="1.35*" />
+                <ColumnDefinition Width="10" />
+                <ColumnDefinition Width="1*" />
+            </Grid.ColumnDefinitions>
+
+            <Border Grid.Column="0" Background="#101824" BorderBrush="#253553"
+                    BorderThickness="1" CornerRadius="10" Padding="10,9">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+                    <TextBlock Text="ПРОВЕРКА ЦЕЛЕЙ" FontFamily="Segoe UI" FontSize="10"
+                               FontWeight="SemiBold" Foreground="#8495B2" />
+                    <TextBlock Grid.Row="1" Text="{Binding ScanCurrentResultText}"
+                               FontFamily="Segoe UI" FontSize="11" Foreground="#8B949E"
+                               TextTrimming="CharacterEllipsis" Margin="0,3,0,8" />
+                    <Border Grid.Row="2" Background="#080C13" CornerRadius="7" Padding="5">
+                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                            <ItemsControl ItemsSource="{Binding ScanTargetChecks}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Border Background="#0D131D" CornerRadius="5" Padding="7,6" Margin="0,2">
+                                            <Grid>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="*" />
+                                                    <ColumnDefinition Width="48" />
+                                                    <ColumnDefinition Width="72" />
+                                                    <ColumnDefinition Width="54" />
+                                                </Grid.ColumnDefinitions>
+                                                <StackPanel Grid.Column="0">
+                                                    <TextBlock Text="{Binding DisplayName}" FontFamily="Segoe UI"
+                                                               FontSize="11" Foreground="#D6E0F0"
+                                                               TextTrimming="CharacterEllipsis" />
+                                                    <TextBlock Text="{Binding DetailText}" FontFamily="Segoe UI"
+                                                               FontSize="9" Foreground="#66758E"
+                                                               TextTrimming="CharacterEllipsis" Margin="0,2,0,0" />
+                                                </StackPanel>
+                                                <TextBlock Grid.Column="1" Text="{Binding TypeText}"
+                                                           FontFamily="Segoe UI" FontSize="9"
+                                                           Foreground="#7788A6" VerticalAlignment="Center"
+                                                           HorizontalAlignment="Center" />
+                                                <StackPanel Grid.Column="2" Orientation="Horizontal"
+                                                            VerticalAlignment="Center" HorizontalAlignment="Center">
+                                                    <TextBlock Text="{Binding StatusGlyph}" Foreground="{Binding ResultColor}"
+                                                               FontFamily="Segoe UI" FontSize="12" FontWeight="Bold"
+                                                               Margin="0,0,4,0" />
+                                                    <TextBlock Text="{Binding ResultText}" Foreground="{Binding ResultColor}"
+                                                               FontFamily="Segoe UI" FontSize="10" VerticalAlignment="Center" />
+                                                </StackPanel>
+                                                <TextBlock Grid.Column="3" Text="{Binding ElapsedText}"
+                                                           FontFamily="Segoe UI" FontSize="9" Foreground="#7788A6"
+                                                           VerticalAlignment="Center" HorizontalAlignment="Right" />
+                                            </Grid>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </ScrollViewer>
+                    </Border>
+                </Grid>
+            </Border>
+
+            <Border Grid.Column="2" Background="#111827" BorderBrush="#2A3550"
+                    BorderThickness="1" CornerRadius="10" Padding="10,9">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+                    <TextBlock Text="ПРОШЕДШИЕ ПРОВЕРКИ" FontFamily="Segoe UI" FontSize="10"
+                               FontWeight="SemiBold" Foreground="#8495B2" />
+                    <TextBlock Grid.Row="1" Text="{Binding ScanPassedSummary}"
+                               FontFamily="Segoe UI" FontSize="11" Foreground="#8B949E"
+                               TextWrapping="Wrap" Margin="0,3,0,8" />
+                    <Border Grid.Row="2" Background="#080C13" CornerRadius="7" Padding="5">
+                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                            <ItemsControl ItemsSource="{Binding ScanPassedProfiles}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Border Background="#0D131D" BorderBrush="#1C2940"
+                                                BorderThickness="1" CornerRadius="6"
+                                                Padding="8,7" Margin="0,2">
+                                            <Grid>
+                                                <Grid.RowDefinitions>
+                                                    <RowDefinition Height="Auto" />
+                                                    <RowDefinition Height="Auto" />
+                                                </Grid.RowDefinitions>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="*" />
+                                                    <ColumnDefinition Width="Auto" />
+                                                </Grid.ColumnDefinitions>
+                                                <TextBlock Grid.Column="0" Text="{Binding DisplayName}"
+                                                           FontFamily="Segoe UI" FontSize="11" Foreground="#DCE4F0"
+                                                           TextTrimming="CharacterEllipsis" />
+                                                <TextBlock Grid.Column="1" Text="{Binding ScoreText}"
+                                                           FontFamily="Segoe UI" FontSize="11" FontWeight="Bold"
+                                                           Foreground="#58A6FF" HorizontalAlignment="Right"
+                                                           Margin="8,0,0,0" />
+                                                <TextBlock Grid.Row="1" Grid.ColumnSpan="2"
+                                                           Text="{Binding DetailText}"
+                                                           FontFamily="Segoe UI" FontSize="9" Foreground="#7788A6"
+                                                           TextWrapping="Wrap" Margin="0,3,0,0" />
+                                            </Grid>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </ScrollViewer>
+                    </Border>
+                </Grid>
+            </Border>
+        </Grid>
+    </Grid>
 </UserControl>

--- a/FluxRoute/ViewModels/MainViewModel.Orchestrator.cs
+++ b/FluxRoute/ViewModels/MainViewModel.Orchestrator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -85,10 +86,106 @@ public sealed partial class AiStrategyRowVm : ObservableObject
     }
 }
 
+public sealed partial class ScanTargetCheckVm : ObservableObject
+{
+    public string Identity { get; }
+    public string DisplayName { get; }
+    public string TypeText { get; }
+
+    [ObservableProperty] private string statusGlyph = "·";
+    [ObservableProperty] private string resultText = "ожидание";
+    [ObservableProperty] private string resultColor = "#66758E";
+    [ObservableProperty] private string detailText = "Ожидает проверки";
+    [ObservableProperty] private string elapsedText = "—";
+
+    public ScanTargetCheckVm(TargetEntry target)
+    {
+        Identity = $"{target.Key}|{target.Value}";
+        DisplayName = GetDisplayName(target);
+        TypeText = target.Kind == TargetKind.Ping ? "PING" : "САЙТ";
+    }
+
+    public void Reset()
+    {
+        StatusGlyph = "·";
+        ResultText = "ожидание";
+        ResultColor = "#66758E";
+        DetailText = "Ожидает проверки";
+        ElapsedText = "—";
+    }
+
+    public void SetResult(CheckResult result)
+    {
+        var ok = result.Ok;
+        StatusGlyph = ok ? "✓" : "×";
+        ResultText = ok ? "OK" : "сбой";
+        ResultColor = ok ? "#38D9A9" : "#FF6B6B";
+        DetailText = string.IsNullOrWhiteSpace(result.Detail)
+            ? (ok ? "Цель доступна" : "Цель недоступна")
+            : result.Detail;
+        ElapsedText = result.ElapsedMs is { } elapsed ? $"{elapsed} мс" : "—";
+    }
+
+    private static string GetDisplayName(TargetEntry target)
+    {
+        if (target.Kind == TargetKind.Ping)
+            return target.Value;
+
+        if (Uri.TryCreate(target.Value, UriKind.Absolute, out var uri))
+            return uri.Host;
+
+        return string.IsNullOrWhiteSpace(target.Key) ? target.Value : target.Key;
+    }
+}
 public partial class MainViewModel
 {
     private const int MaxLogEntries = 50;
+    public ObservableCollection<ScanTargetCheckVm> ScanTargetChecks { get; } = new();
+    public ObservableCollection<ProfileScore> ScanPassedProfiles { get; } = new();
+    [ObservableProperty] private string scanPassedSummary = "Пока ни одна стратегия не прошла проверку.";
 
+
+    private void ResetScanTargetChecks(IEnumerable<TargetEntry> targets)
+    {
+        ScanTargetChecks.Clear();
+        foreach (var target in targets)
+            ScanTargetChecks.Add(new ScanTargetCheckVm(target));
+    }
+
+    private void ResetCurrentScanTargetChecks()
+    {
+        foreach (var target in ScanTargetChecks)
+            target.Reset();
+    }
+
+    private void UpdateScanTargetCheck(CheckResult result)
+    {
+        var identity = $"{result.Key}|{result.Value}";
+        var target = ScanTargetChecks.FirstOrDefault(x =>
+            string.Equals(x.Identity, identity, StringComparison.OrdinalIgnoreCase) ||
+            (string.Equals(x.DisplayName, result.Value, StringComparison.OrdinalIgnoreCase) &&
+             string.Equals(x.TypeText, result.Kind == TargetKind.Ping ? "PING" : "САЙТ", StringComparison.OrdinalIgnoreCase)));
+        target?.SetResult(result);
+    }
+
+    private void UpdateScanBestStrategyText()
+    {
+        var top = ProfileScores.Where(s => s.Score > 0).OrderByDescending(s => s.Score).FirstOrDefault();
+        ScanBestStrategyText = top is null
+            ? "Рабочая стратегия не найдена"
+            : $"{top.DisplayName} · {top.ScoreText}";
+    }
+
+    private void RebuildPassedScanProfiles()
+    {
+        ScanPassedProfiles.Clear();
+        foreach (var score in ProfileScores.Where(x => x.Score > 0))
+            ScanPassedProfiles.Add(score);
+
+        ScanPassedSummary = ScanPassedProfiles.Count == 0
+            ? "Пока ни одна стратегия не прошла проверку."
+            : $"Прошли проверку: {ScanPassedProfiles.Count}";
+    }
     private void AddOrchestratorLog(string message)
     {
         OrchestratorLogs.Add(message);
@@ -110,6 +207,18 @@ public partial class MainViewModel
             {
                 AddOrchestratorLog(e.Message);
                 OrchestratorStatus = e.Message;
+
+                if (e.ProbeResult is not null && IsScanning && e.ProbeResult.Profile is not null)
+                {
+                    var liveScore = ProfileScores.FirstOrDefault(s =>
+                        s.FileName == e.ProbeResult.Profile.FileName);
+                    liveScore?.SetProbeResult(e.ProbeResult);
+                    foreach (var check in e.ProbeResult.Checks)
+                        UpdateScanTargetCheck(check);
+                    RebuildPassedScanProfiles();
+                    ScanCurrentStrategy = e.ProbeResult.ProfileName;
+                    ScanCurrentResultText = $"{e.ProbeResult.Score}% · {e.ProbeResult.Summary}";
+                }
 
                 if (e.Message.Contains("Сканирование завершено", StringComparison.OrdinalIgnoreCase))
                 {
@@ -499,6 +608,7 @@ public partial class MainViewModel
 
     // ── CancellationTokenSource для отмены сканирования ──
     private CancellationTokenSource? _scanCts;
+    private StrategyScanWindow? _scanWindow;
     private int _scanGeneration;
 
     // ── Статус сканирования (для ScanProgressView) ──
@@ -510,9 +620,57 @@ public partial class MainViewModel
     private int _scanCurrentCount;
     private System.Windows.Threading.DispatcherTimer? _scanEtaTimer;
 
+    [ObservableProperty] private string scanTargetsText = "Подготовка целей...";
+    [ObservableProperty] private string scanCurrentStrategy = "Подготовка...";
+    [ObservableProperty] private string scanCurrentResultText = "Ожидаю первый результат...";
+    [ObservableProperty] private string scanBestStrategyText = "Пока нет результата";
+    [ObservableProperty] private bool hasScanResult;
+
+    public bool CanViewScanResult => HasScanResult && !IsScanning;
+
+    partial void OnIsScanningChanged(bool value)
+    {
+        OnPropertyChanged(nameof(CanViewScanResult));
+    }
+
+    partial void OnHasScanResultChanged(bool value)
+    {
+        OnPropertyChanged(nameof(CanViewScanResult));
+    }
+
     /// <summary>Признак, что сканирование можно отменить (показываем кнопку "Остановить").</summary>
     public bool CanCancelScan => IsScanning;
 
+    private StrategyScanWindow CreateScanWindow()
+    {
+        var window = new StrategyScanWindow { DataContext = this };
+        if (Application.Current.MainWindow is { IsLoaded: true } owner)
+            window.Owner = owner;
+        window.Closed += (_, _) =>
+        {
+            if (ReferenceEquals(_scanWindow, window))
+                _scanWindow = null;
+        };
+        return window;
+    }
+
+    [RelayCommand]
+    private void ViewScanResult()
+    {
+        if (!HasScanResult)
+            return;
+
+        if (_scanWindow is { IsVisible: true } visibleWindow)
+        {
+            if (visibleWindow.WindowState == System.Windows.WindowState.Minimized)
+                visibleWindow.WindowState = System.Windows.WindowState.Normal;
+            visibleWindow.Activate();
+            return;
+        }
+
+        _scanWindow = CreateScanWindow();
+        _scanWindow.Show();
+    }
     [RelayCommand]
     private void CancelScan()
     {
@@ -526,8 +684,14 @@ public partial class MainViewModel
         IsScanning = false;
         GlobalOverlayVisible = false;
         OnPropertyChanged(nameof(CanCancelScan));
-        ScanProgressText = "";
-        ScanProgressValue = 0;
+        RebuildPassedScanProfiles();
+        UpdateScanBestStrategyText();
+        HasScanResult = true;
+        ScanStatusText = "⏹ Сканирование остановлено";
+        ScanProgressText = _scanTotalCount > 0
+            ? $"Остановлено на {_scanCurrentCount}/{_scanTotalCount}"
+            : "Сканирование остановлено";
+        ScanTimeRemaining = "⏹ Остановлено";
         AddOrchestratorLog($"[{DateTime.Now:HH:mm:ss}] ⏹ Сканирование остановлено пользователем.");
     }
 
@@ -551,9 +715,22 @@ public partial class MainViewModel
         }
     }
 
+    private string BuildScanTargetsText()
+    {
+        var sites = _orchestrator.EnabledSites
+            .OrderBy(site => site, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var customCount = _orchestrator.UserSiteTargets.Count;
+        var targetText = sites.Count == 0 ? "цели не выбраны" : string.Join(" · ", sites);
+        return customCount > 0 ? $"{targetText} · своих доменов: {customCount}" : targetText;
+    }
+
     [RelayCommand]
     private async Task ScanProfiles()
     {
+        if (IsScanning)
+            return;
         // Счётчик поколений: только последний вызов сбрасывает IsScanning в finally
         var gen = ++_scanGeneration;
 
@@ -565,17 +742,26 @@ public partial class MainViewModel
 
         _orchestrator.ClearRankedProfiles();
         RebuildProfileScores();
+        ResetScanTargetChecks(_orchestrator.GetScanTargets());
+        ScanPassedProfiles.Clear();
+        ScanPassedSummary = "Пока ни одна стратегия не прошла проверку.";
+        HasScanResult = false;
         IsScanning = true;
-        GlobalOverlayTitle = "Сканирование стратегий";
-        GlobalOverlayContent = new ScanProgressView { DataContext = this };
-        GlobalOverlayCloseCommand = CancelScanCommand;
-        GlobalOverlayVisible = true;
+        GlobalOverlayVisible = false;
+        if (_scanWindow is { IsVisible: true } oldWindow)
+            oldWindow.Close();
+        _scanWindow = CreateScanWindow();
+        _scanWindow.Show();
         OnPropertyChanged(nameof(CanCancelScan));
         ScanStatusText = "Подготовка...";
         ScanProgressText = "Сканирование...";
         ScanProgressValue = 0;
         ScanTimeRemaining = "";
         ScanElapsed = "";
+        ScanTargetsText = "Подготовка целей...";
+        ScanCurrentStrategy = "Подготовка...";
+        ScanCurrentResultText = "Ожидаю первый результат...";
+        ScanBestStrategyText = "Пока нет результата";
         _scanStartTime = DateTime.Now;
         _scanTotalCount = 0;
         _scanCurrentCount = 0;
@@ -589,10 +775,13 @@ public partial class MainViewModel
         _scanEtaTimer.Start();
 
         UpdateOrchestratorEnabledSites();
+        ScanTargetsText = BuildScanTargetsText();
         var wasRunning = IsTrackedProcessRunning();
 
         // Определяем общее количество стратегий для ETA
         _scanTotalCount = Profiles.Count;
+
+        var checkProgress = new Progress<CheckResult>(UpdateScanTargetCheck);
 
         var progress = new Progress<(int current, int total)>(report =>
         {
@@ -604,14 +793,22 @@ public partial class MainViewModel
             ScanProgressValue = percent;
             ScanStatusText = $"[{report.current}/{report.total}] Тестирую стратегии...";
             ScanProgressText = $"Сканирование... {report.current}/{report.total}";
+            ResetCurrentScanTargetChecks();
+            ScanCurrentStrategy = report.current > 0 && report.current <= Profiles.Count
+                ? Profiles[report.current - 1].DisplayName
+                : "Проверка следующей стратегии...";
+            ScanCurrentResultText = "Проверяю стабильность winws и доступность целей...";
             UpdateScanEta();
         });
 
         try
         {
             _suppressOrchestratorStop = true;
-            await _orchestrator.ScanAllProfilesAsync(scanCt, progress);
+            await _orchestrator.ScanAllProfilesAsync(scanCt, progress, checkProgress);
             SortProfileScores();
+            RebuildPassedScanProfiles();
+            UpdateScanBestStrategyText();
+            HasScanResult = true;
             ScanStatusText = "Сканирование завершено";
             ScanProgressText = "Сканирование завершено";
             ScanProgressValue = 100;
@@ -619,6 +816,9 @@ public partial class MainViewModel
             SaveSettings();
 
             var top = ProfileScores.FirstOrDefault(s => s.Score > 0);
+            ScanBestStrategyText = top is null
+                ? "Рабочая стратегия не найдена"
+                : $"{top.DisplayName} · {top.ScoreText}";
             if (top is not null)
             {
                 var profile = Profiles.FirstOrDefault(p => p.FileName == top.FileName);
@@ -648,6 +848,9 @@ public partial class MainViewModel
         {
             if (gen == _scanGeneration)
             {
+                RebuildPassedScanProfiles();
+                UpdateScanBestStrategyText();
+                HasScanResult = true;
                 ScanStatusText = $"❌ Ошибка: {ex.Message}";
                 ScanProgressText = "Ошибка сканирования";
                 ScanProgressValue = 0;

--- a/FluxRoute/Views/StrategyScanWindow.xaml
+++ b/FluxRoute/Views/StrategyScanWindow.xaml
@@ -1,0 +1,70 @@
+<Window x:Class="FluxRoute.Views.StrategyScanWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="clr-namespace:FluxRoute.Controls"
+        Title="Подбор стратегии"
+        Width="920" Height="660"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Background="Transparent"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        ShowInTaskbar="False"
+        Loaded="Window_Loaded"
+        Closing="Window_Closing"
+        MouseLeftButtonDown="Window_MouseLeftButtonDown">
+    <Border Background="#0C0F17" CornerRadius="14"
+            BorderBrush="#263858" BorderThickness="1">
+        <Grid Margin="18,14">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <Grid Grid.Row="0" Margin="0,0,0,12">
+                <StackPanel>
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="&#xE99A;" FontFamily="Segoe MDL2 Assets"
+                                   FontSize="17" Foreground="#4D6BFE"
+                                   VerticalAlignment="Center" Margin="0,0,8,0" />
+                        <TextBlock Text="Подбор стратегии" Foreground="#DCE4F0"
+                                   FontSize="15" FontWeight="SemiBold"
+                                   VerticalAlignment="Center" />
+                    </StackPanel>
+                    <TextBlock Text="Проверяем доступность целей и выбираем наиболее стабильный вариант."
+                               Foreground="#66758E" FontSize="10" Margin="25,3,30,0"
+                               TextWrapping="Wrap" />
+                </StackPanel>
+
+            </Grid>
+
+            <Border Grid.Row="1" Background="#080B12"
+                    BorderBrush="#1E2235" BorderThickness="1"
+                    CornerRadius="10" Padding="14,12">
+                <controls:ScanProgressView />
+            </Border>
+
+            <Grid Grid.Row="2" Margin="0,10,0,0">
+                <TextBlock Text="Можно закрыть окно — текущая проверка будет остановлена."
+                           Foreground="#55647D" FontSize="10"
+                           VerticalAlignment="Center" />
+                <Button
+                        Height="30" Padding="12,0"
+                        HorizontalAlignment="Right"
+                        Click="CloseButton_Click">
+                    <Button.Style>
+                        <Style TargetType="Button" BasedOn="{StaticResource ActionBtnRed}">
+                            <Setter Property="Content" Value="Остановить и закрыть" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding IsScanning}" Value="False">
+                                    <Setter Property="Content" Value="Закрыть результат" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Button.Style>
+                </Button>
+            </Grid>
+        </Grid>
+    </Border>
+</Window>

--- a/FluxRoute/Views/StrategyScanWindow.xaml.cs
+++ b/FluxRoute/Views/StrategyScanWindow.xaml.cs
@@ -1,0 +1,58 @@
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Input;
+using FluxRoute.ViewModels;
+
+namespace FluxRoute.Views;
+
+/// <summary>
+/// Отдельное окно подбора стратегий с живым прогрессом и результатами.
+/// </summary>
+public partial class StrategyScanWindow : Window
+{
+    private MainViewModel? _viewModel;
+
+    public StrategyScanWindow()
+    {
+        InitializeComponent();
+    }
+
+    private void Window_Loaded(object sender, RoutedEventArgs e)
+    {
+        if (DataContext is not MainViewModel vm)
+            return;
+
+        _viewModel = vm;
+    }
+
+    private void CloseButton_Click(object sender, RoutedEventArgs e)
+    {
+        CancelScanIfRunning();
+        Close();
+    }
+
+    private void Window_Closing(object? sender, CancelEventArgs e)
+    {
+        CancelScanIfRunning();
+    }
+
+    private void CancelScanIfRunning()
+    {
+        if (_viewModel?.IsScanning == true &&
+            _viewModel.CancelScanCommand.CanExecute(null))
+        {
+            _viewModel.CancelScanCommand.Execute(null);
+        }
+    }
+
+    private void Window_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (e.ChangedButton == MouseButton.Left)
+            DragMove();
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        base.OnClosed(e);
+    }
+}

--- a/FluxRoute/Views/Tabs/DiagnosticsPage.xaml
+++ b/FluxRoute/Views/Tabs/DiagnosticsPage.xaml
@@ -4,8 +4,13 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              mc:Ignorable="d" d:DesignHeight="460" d:DesignWidth="760">
-    <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <StackPanel Margin="16,12">
+    <Grid Margin="16,12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <StackPanel Grid.Row="0">
             <TextBlock Style="{StaticResource SecH}" Text="СОСТОЯНИЕ КОМПОНЕНТОВ" Margin="0,0,0,8" />
             <Grid Margin="0,0,0,12">
                 <Grid.ColumnDefinitions>
@@ -33,7 +38,8 @@
                 <TextBlock Grid.Row="5" Grid.Column="0" Style="{StaticResource Lbl}" Text="Версия приложения:" />
                 <TextBlock Grid.Row="5" Grid.Column="1" Style="{StaticResource Val}" Text="{Binding AppVersion}" />
             </Grid>
-            <WrapPanel>
+            </StackPanel>
+            <WrapPanel Grid.Row="1">
                 <Button Content="🔍 Запустить диагностику" Style="{StaticResource ActionBtnAccent}"
                     Margin="0,0,8,8" Command="{Binding RunExtendedDiagnosticsCommand}"
                     IsEnabled="{Binding IsExtendedDiagnosticsRunning, Converter={StaticResource InvBool}}"
@@ -50,7 +56,7 @@
             </WrapPanel>
 
             <!-- Результаты расширенной диагностики -->
-            <Border Background="#0D1117" BorderBrush="#30363D" BorderThickness="1"
+            <Border Grid.Row="2" Background="#0D1117" BorderBrush="#30363D" BorderThickness="1"
                 CornerRadius="6" Padding="12" Margin="0,12,0,0"
                 Visibility="{Binding ExtendedDiagnosticsVisible, Converter={StaticResource BoolToVis}}">
                 <Grid>
@@ -83,7 +89,7 @@
                         </StackPanel>
                     </Grid>
 
-                    <ScrollViewer Grid.Row="1" MaxHeight="340" VerticalScrollBarVisibility="Auto">
+                    <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
                         <ItemsControl ItemsSource="{Binding ExtendedDiagnosticsResults}">
                             <ItemsControl.ItemTemplate>
                                 <DataTemplate>
@@ -96,6 +102,5 @@
                     </ScrollViewer>
                 </Grid>
             </Border>
-        </StackPanel>
-    </ScrollViewer>
+        </Grid>
 </UserControl>

--- a/FluxRoute/Views/Tabs/HomePage.xaml
+++ b/FluxRoute/Views/Tabs/HomePage.xaml
@@ -529,7 +529,7 @@
 <!-- Всплывающее управление режимом -->
         <Popup x:Name="ProtectionModePopup"
                PlacementTarget="{Binding ElementName=ModeToggleButton}"
-               Placement="Right" HorizontalOffset="10" VerticalOffset="-132"
+               Placement="Bottom" HorizontalOffset="-64" VerticalOffset="8"
                AllowsTransparency="True" StaysOpen="False" PopupAnimation="Fade">
             <Border x:Name="ProtectionModeCard"
                     Style="{StaticResource DashboardCard}"

--- a/FluxRoute/Views/Tabs/OrchestratorPage.xaml
+++ b/FluxRoute/Views/Tabs/OrchestratorPage.xaml
@@ -88,80 +88,17 @@
                         </Style>
                     </Button.Style>
                 </Button>
+                <Button Content="Посмотреть результат" Style="{StaticResource ActionBtn}"
+                        Margin="0,0,8,0"
+                        IsEnabled="{Binding CanViewScanResult}"
+                        Command="{Binding ViewScanResultCommand}"
+                        ToolTip="Открыть последнее сохранённое сканирование" />
                 <!-- ═══ v1.6.0: Feature #53 — Кнопка сброса рейтинга ═══ -->
                 <Button Content="🔄 Сбросить рейтинг" Style="{StaticResource RedBtn}"
                         Padding="12,5" FontSize="12"
                         Command="{Binding ResetProfileRatingsCommand}"
                         ToolTip="Очистить историю оценок оркестратора и ИИ" />
             </StackPanel>
-
-            <!-- Прогресс-бар сканирования (без Storyboard — анимация сбивалась при быстрых переключениях IsScanning) -->
-            <Border Margin="0,0,0,8" CornerRadius="6" Padding="10,8"
-                    Visibility="{Binding IsScanning, Converter={StaticResource BoolToVis}}"
-                    Background="#0E1120" BorderBrush="#1E2235" BorderThickness="1">
-                <StackPanel>
-                    <Grid Margin="0,0,0,6">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        <TextBlock Grid.Column="0" Text="{Binding ScanProgressText}" FontFamily="Segoe UI"
-                                   Foreground="#4A90E2" FontSize="12" FontWeight="SemiBold"
-                                   VerticalAlignment="Center" />
-                        <StackPanel Grid.Column="1" Orientation="Horizontal">
-                            <TextBlock Text="{Binding ScanProgressValue, StringFormat={}{0:0}%}"
-                                       FontFamily="Segoe UI" Foreground="#8B949E" FontSize="11"
-                                       VerticalAlignment="Center" Margin="0,0,8,0" />
-                            <Button Content="⏹ Остановить" Height="26" Padding="10,0"
-                                    Style="{StaticResource RedBtn}" FontSize="11"
-                                    Command="{Binding CancelScanCommand}" />
-                        </StackPanel>
-                    </Grid>
-                    <ProgressBar Value="{Binding ScanProgressValue}" Minimum="0" Maximum="100"
-                                 Height="6" Background="#21262D" Foreground="#58A6FF"
-                                 BorderThickness="0">
-                        <ProgressBar.Template>
-                            <ControlTemplate TargetType="ProgressBar">
-                                <Border Background="{TemplateBinding Background}" CornerRadius="3">
-                                    <Grid>
-                                        <Border x:Name="PART_Track" />
-                                        <Border x:Name="PART_Indicator" CornerRadius="3"
-                                                HorizontalAlignment="Left">
-                                            <Border.Background>
-                                                <LinearGradientBrush StartPoint="0,0" EndPoint="1,0">
-                                                    <GradientStop Color="#58A6FF" Offset="0" />
-                                                    <GradientStop Color="#9966FF" Offset="1" />
-                                                </LinearGradientBrush>
-                                            </Border.Background>
-                                        </Border>
-                                    </Grid>
-                                </Border>
-                            </ControlTemplate>
-                        </ProgressBar.Template>
-                    </ProgressBar>
-                </StackPanel>
-            </Border>
-
-            <ItemsControl ItemsSource="{Binding ProfileScores}">
-                <ItemsControl.ItemTemplate>
-                    <DataTemplate>
-                        <Border Background="#111520" CornerRadius="6" Padding="10,6" Margin="0,2">
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <TextBlock Grid.Column="0" Text="{Binding DisplayName}"
-                                           FontFamily="Segoe UI" Foreground="#C8D4EC" FontSize="12"
-                                           VerticalAlignment="Center" />
-                                <TextBlock Grid.Column="1" Text="{Binding ScoreText}"
-                                           FontFamily="Segoe UI" Foreground="#4A90E2" FontSize="12"
-                                           FontWeight="Bold" VerticalAlignment="Center" />
-                            </Grid>
-                        </Border>
-                    </DataTemplate>
-                </ItemsControl.ItemTemplate>
-            </ItemsControl>
-        </StackPanel>
+</StackPanel>
     </ScrollViewer>
 </UserControl>


### PR DESCRIPTION
## Что изменено

- добавлено отдельное окно подбора стратегий с живым прогрессом и результатами проверки;
- добавлено сохранение и повторный просмотр результата сканирования;
- обновлён интерфейс оркестратора и кнопки управления рейтингом стратегий;
- увеличена читаемость текста в окне проверки, окно сделано фиксированного размера 920×660;
- блок результатов диагностики растягивается по доступной высоте;
- попап режима защиты открывается рядом с кнопкой и не меняет положение при полноэкранном режиме.

## Зачем

Изменения делают подбор стратегий и диагностику понятнее: прогресс и результаты видны в отдельном окне, а элементы управления не прыгают при изменении размера приложения.

## Проверка

- `dotnet restore FluxRoute\FluxRoute.csproj -r win-x64`
- `dotnet build FluxRoute\FluxRoute.csproj --no-restore -c Release -r win-x64`
- сборка завершена успешно, ошибок нет.