### PR TITLE
fix(ui): исправить отображение иконки кнопки питания

### DIFF
--- a/FluxRoute/Controls/ScanProgressView.xaml
+++ b/FluxRoute/Controls/ScanProgressView.xaml
@@ -38,7 +38,7 @@
                 CornerRadius="8" Padding="10,9" Margin="0,0,0,10">
             <StackPanel>
                 <Grid Margin="0,0,0,5">
-                    <TextBlock Text="{Binding ScanStatusText}" FontFamily="Segoe UI" FontSize="12"
+                    <TextBlock Text="{Binding ScanStatusText}" FontFamily="Segoe UI Symbol" FontSize="12"
                                Foreground="#C8D4EC" />
                     <TextBlock Text="{Binding ScanProgressValue, StringFormat={}{0:0}%}"
                                HorizontalAlignment="Right" FontFamily="Segoe UI" FontSize="12"
@@ -67,7 +67,7 @@
                     </ProgressBar.Template>
                 </ProgressBar>
                 <Grid Margin="0,6,0,0">
-                    <TextBlock Text="{Binding ScanTimeRemaining}" FontFamily="Segoe UI" FontSize="11"
+                    <TextBlock Text="{Binding ScanTimeRemaining}" FontFamily="Segoe UI Symbol" FontSize="11"
                                Foreground="#66758E" />
                     <TextBlock Text="{Binding ScanElapsed}" HorizontalAlignment="Right"
                                FontFamily="Segoe UI" FontSize="11" Foreground="#66758E" />

--- a/FluxRoute/Views/DonateWindow.xaml
+++ b/FluxRoute/Views/DonateWindow.xaml
@@ -14,7 +14,7 @@
             MouseLeftButtonDown="Window_MouseLeftButtonDown">
         <StackPanel Margin="24,20">
             <StackPanel Orientation="Horizontal" Margin="0,0,0,12">
-                <TextBlock Text="♥" FontSize="16" Foreground="#F85149" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                <TextBlock Text="♥" FontFamily="Segoe UI Symbol" FontSize="16" Foreground="#F85149" VerticalAlignment="Center" Margin="0,0,8,0"/>
                 <TextBlock Text="Поддержать автора" FontFamily="Segoe UI" FontSize="16"
                            FontWeight="SemiBold" Foreground="#C8D4EC" VerticalAlignment="Center"/>
             </StackPanel>

--- a/FluxRoute/Views/Tabs/AiPage.xaml
+++ b/FluxRoute/Views/Tabs/AiPage.xaml
@@ -45,9 +45,9 @@
                 <TextBlock Grid.Row="2" Grid.Column="1" Style="{StaticResource Val}" Text="{Binding AiProbeCountText}" />
             </Grid>
             <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-                <Button Content="⚗ Эволюция сейчас" Style="{StaticResource AccentBtn}"
+                <Button Content="⚗ Эволюция сейчас" FontFamily="Segoe UI Symbol" Style="{StaticResource AccentBtn}"
                     Margin="0,0,10,0" Command="{Binding RunAiEvolutionCommand}" />
-                <Button Content="↺ Сброс модели" Style="{StaticResource TermBtn}"
+                <Button Content="↺ Сброс модели" FontFamily="Segoe UI Symbol" Style="{StaticResource TermBtn}"
                     Margin="0,0,10,0" Command="{Binding ResetAiModelCommand}" />
                 <Button Content="📁 ai-evolved" Style="{StaticResource TermBtn}"
                     Margin="0,0,10,0" Command="{Binding OpenAiEvolvedFolderCommand}" />

--- a/FluxRoute/Views/Tabs/DiagnosticsPage.xaml
+++ b/FluxRoute/Views/Tabs/DiagnosticsPage.xaml
@@ -80,7 +80,7 @@
                             <TextBlock FontFamily="Segoe UI" FontSize="12" FontWeight="SemiBold"
                                 Foreground="#4A90E2" Margin="0,0,12,0" VerticalAlignment="Center"
                                 Text="Результаты диагностики" />
-                            <TextBlock FontFamily="Segoe UI" FontSize="11" Foreground="#8B949E"
+                            <TextBlock FontFamily="Segoe UI Symbol" FontSize="11" Foreground="#8B949E"
                                 VerticalAlignment="Center"
                                 Visibility="{Binding IsExtendedDiagnosticsRunning, Converter={StaticResource BoolToVis}}"
                                 Text="⏳ Выполняется..." />

--- a/FluxRoute/Views/Tabs/HomePage.xaml
+++ b/FluxRoute/Views/Tabs/HomePage.xaml
@@ -235,7 +235,12 @@
                         <ControlTemplate TargetType="Button">
                             <Border x:Name="ButtonSurface" Background="Transparent" CornerRadius="76">
                                 <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-                                    <TextBlock Text="⏻" FontSize="48" Foreground="#55AAFF" HorizontalAlignment="Center" />
+                                    <!-- Векторная иконка не зависит от наличия символа ⏻ в системном шрифте. -->
+                                    <Path Width="42" Height="42" Stretch="Uniform"
+                                          Stroke="#55AAFF" StrokeThickness="2.5"
+                                          StrokeStartLineCap="Round" StrokeEndLineCap="Round"
+                                          HorizontalAlignment="Center"
+                                          Data="M12,2 V12 M6.5,5.5 A9,9 0 1 0 17.5,5.5" />
                                     <TextBlock FontFamily="Segoe UI" FontSize="12" FontWeight="SemiBold"
                                                HorizontalAlignment="Center" Margin="0,8,0,0">
                                         <TextBlock.Style>
@@ -476,7 +481,7 @@
                         <Border Grid.Column="0" Background="#0D1422" BorderBrush="#1C2940"
                                 BorderThickness="1" CornerRadius="8" Padding="10,8">
                             <StackPanel>
-                                <TextBlock Text="↓ СКАЧИВАНИЕ" Style="{StaticResource MetricLabel}" />
+                                <TextBlock FontFamily="Segoe UI Symbol" Text="↓ СКАЧИВАНИЕ" Style="{StaticResource MetricLabel}" />
                                 <TextBlock Text="{Binding DownloadSpeed}" Foreground="#55AAFF"
                                            FontFamily="Segoe UI" FontSize="17" FontWeight="SemiBold"
                                            Margin="0,3,0,0" TextTrimming="CharacterEllipsis" />
@@ -487,7 +492,7 @@
                         <Border Grid.Column="2" Background="#0D1422" BorderBrush="#1C2940"
                                 BorderThickness="1" CornerRadius="8" Padding="10,8">
                             <StackPanel>
-                                <TextBlock Text="↑ ОТДАЧА" Style="{StaticResource MetricLabel}" />
+                                <TextBlock FontFamily="Segoe UI Symbol" Text="↑ ОТДАЧА" Style="{StaticResource MetricLabel}" />
                                 <TextBlock Text="{Binding UploadSpeed}" Foreground="#7755EE"
                                            FontFamily="Segoe UI" FontSize="17" FontWeight="SemiBold"
                                            Margin="0,3,0,0" TextTrimming="CharacterEllipsis" />
@@ -571,7 +576,7 @@
                                     </Style>
                                 </Button.Style>
                                 <StackPanel Orientation="Horizontal">
-                                    <TextBlock Text="◈" FontSize="13" Margin="0,0,6,0" />
+                                    <TextBlock Text="◈" FontFamily="Segoe UI Symbol" FontSize="13" Margin="0,0,6,0" />
                                     <TextBlock Text="Автовыбор" FontSize="11" FontWeight="SemiBold" />
                                 </StackPanel>
                             </Button>
@@ -588,7 +593,7 @@
                                     </Style>
                                 </Button.Style>
                                 <StackPanel Orientation="Horizontal">
-                                    <TextBlock Text="≡" FontSize="15" Margin="0,0,6,0" />
+                                    <TextBlock Text="≡" FontFamily="Segoe UI Symbol" FontSize="15" Margin="0,0,6,0" />
                                     <TextBlock Text="Вручную" FontSize="11" FontWeight="SemiBold" />
                                 </StackPanel>
                             </Button>

--- a/FluxRoute/Views/Tabs/OrchestratorPage.xaml
+++ b/FluxRoute/Views/Tabs/OrchestratorPage.xaml
@@ -17,6 +17,7 @@
                 <Button Margin="0,0,10,0" Command="{Binding ToggleOrchestratorCommand}">
                     <Button.Style>
                         <Style TargetType="Button" BasedOn="{StaticResource ActionBtn}">
+                            <Setter Property="FontFamily" Value="Segoe UI Symbol" />
                             <Setter Property="Content" Value="▶ Включить оркестратор" />
                             <Style.Triggers>
                                 <DataTrigger Binding="{Binding OrchestratorEnabled}" Value="True">

--- a/FluxRoute/Views/Tabs/ServicePage.xaml
+++ b/FluxRoute/Views/Tabs/ServicePage.xaml
@@ -54,7 +54,7 @@
                                             <Run Text="{Binding TriggerProcess}" />
                                         </TextBlock>
                                     </StackPanel>
-                                    <Button Grid.Column="1" Content="▶ Применить"
+                                    <Button Grid.Column="1" Content="▶ Применить" FontFamily="Segoe UI Symbol"
                                             Style="{StaticResource ActionBtn}"
                                             Command="{Binding DataContext.ApplyPresetCommand, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
                                             CommandParameter="{Binding}"
@@ -190,7 +190,7 @@
                             </DataTemplate>
                         </ComboBox.ItemTemplate>
                     </ComboBox>
-                    <Button Grid.Column="2" Content="✖"
+                    <Button Grid.Column="2" Content="✖" FontFamily="Segoe UI Symbol"
                             Style="{StaticResource RedBtn}" Width="28" Height="28"
                             Padding="0" FontSize="14" Margin="6,0,0,0"
                             Command="{Binding ClearDefaultProfileCommand}"

--- a/FluxRoute/Views/Tabs/TgProxyPage.xaml
+++ b/FluxRoute/Views/Tabs/TgProxyPage.xaml
@@ -71,6 +71,7 @@
                             <Button Command="{Binding ToggleTgProxyCommand}" IsEnabled="{Binding TgProxyInstalled}" Margin="0,0,8,6">
                                 <Button.Style>
                                     <Style TargetType="Button" BasedOn="{StaticResource ActionBtnGreen}">
+                                        <Setter Property="FontFamily" Value="Segoe UI Symbol" />
                                         <Setter Property="Content" Value="▶ Запустить прокси" />
                                         <Style.Triggers>
                                             <DataTrigger Binding="{Binding TgProxyRunning}" Value="True">
@@ -126,7 +127,7 @@
                             </Grid.ColumnDefinitions>
                             <TextBox Text="{Binding TgProxySecret, UpdateSourceTrigger=PropertyChanged}" Height="32" FontFamily="Consolas" />
                             <Button Grid.Column="2" Height="32" Width="38" Padding="0" Style="{StaticResource ActionBtnAccent}"
-                                    Command="{Binding GenerateTgProxySecretCommand}" Content="↻" FontSize="15" ToolTip="Сгенерировать новый secret" />
+                                    Command="{Binding GenerateTgProxySecretCommand}" Content="↻" FontFamily="Segoe UI Symbol" FontSize="15" ToolTip="Сгенерировать новый secret" />
                         </Grid>
                     </StackPanel>
                 </Border>

--- a/FluxRoute/Views/Tabs/UserModsPage.xaml
+++ b/FluxRoute/Views/Tabs/UserModsPage.xaml
@@ -27,7 +27,7 @@
                 </StackPanel>
 
                 <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
-                    <Button Content="⟳ GitHub" Style="{StaticResource ActionBtnAccent}"
+                    <Button Content="⟳ GitHub" FontFamily="Segoe UI Symbol" Style="{StaticResource ActionBtnAccent}"
                             Height="28" FontSize="11" Padding="10,4"
                             Margin="0,0,8,0"
                             ToolTip="Синхронизировать моды из GitHub-репозитория"
@@ -99,7 +99,7 @@
                                     </Grid.ColumnDefinitions>
 
                                     <TextBlock Grid.Column="0"
-                                               Text="⋮⋮" FontSize="16"
+                                               Text="⋮⋮" FontFamily="Segoe UI Symbol" FontSize="16"
                                                Foreground="#484F58"
                                                VerticalAlignment="Top"
                                                Margin="0,2,6,0"

--- a/FluxRoute/Views/UpdateCheckDialog.xaml
+++ b/FluxRoute/Views/UpdateCheckDialog.xaml
@@ -101,7 +101,7 @@
                 </Grid.ColumnDefinitions>
                 <Border Width="34" Height="34" CornerRadius="17"
                         Background="#132B28" BorderBrush="#245249" BorderThickness="1">
-                    <TextBlock x:Name="StatusIcon" Text="↻" FontSize="18" Foreground="#5BD6C1"
+                    <TextBlock x:Name="StatusIcon" Text="↻" FontFamily="Segoe UI Symbol" FontSize="18" Foreground="#5BD6C1"
                                HorizontalAlignment="Center" VerticalAlignment="Center" />
                 </Border>
                 <StackPanel Grid.Column="1" VerticalAlignment="Center" Margin="12,0,0,0">


### PR DESCRIPTION
## Что изменено

- Unicode-символ питания ⏻ на главной странице заменён на векторный Path, чтобы кнопка отображалась как корректная иконка, а не как прямоугольник-квадрат при отсутствии нужного глифа в шрифте.
- Для остальных статических Unicode-символов интерфейса явно задан Segoe UI Symbol — это касается кнопок управления, стрелок, обновления, ожидания и других символов.

## Проверка

- Проект собирается без ошибок.
- Все 348 тестов проходят.