### PR TITLE
fix(update): восстановить автоматический перезапуск после обновления

### DIFF
--- a/FluxRoute/Views/MainWindow.xaml.cs
+++ b/FluxRoute/Views/MainWindow.xaml.cs
@@ -267,6 +267,11 @@ public partial class MainWindow : Window
     {
         base.OnClosing(e);
 
+        // Программное закрытие при успешном обновлении не должно попадать
+        // под пользовательское подтверждение или сворачивание в трей.
+        if (Dispatcher.HasShutdownStarted)
+            _isClosingConfirmed = true;
+
         // ═══ v1.6.0: Feature #21 — Крестик сворачивает в трей ═══
         if (_vm.CloseToTray && !_isClosingConfirmed)
         {


### PR DESCRIPTION
## Что исправлено

После обновления приложение вызывало Application.Shutdown(), но обычная логика MainWindow.OnClosing могла отменить закрытие или свернуть окно в трей. Из-за этого приложение не перезапускалось корректно, а собственный winws.exe мог не успеть штатно остановиться.

## Изменение

При программном shutdown, инициированном обновлением, включается режим подтверждённого закрытия. Благодаря этому обходятся пользовательское подтверждение и сворачивание в трей, выполняется штатная очистка приложения, после чего updater может корректно запустить новую версию.

## Проверка

- Проект собирается без ошибок.
- Все 348 тестов проходят.