### PR TITLE
fix: preserve working orchestrator profile

### DIFF
--- a/FluxRoute.Core.Tests/ScanOverlayTests.cs
+++ b/FluxRoute.Core.Tests/ScanOverlayTests.cs
@@ -34,6 +34,29 @@ public sealed class ScanOverlayTests : IDisposable
         try { Directory.Delete(_tempDir, recursive: true); } catch { }
     }
 
+    [Fact]
+    public void RestoreRankedProfiles_EqualScores_PrefersPersistedProfile()
+    {
+        var connectivityMock = new Mock<IConnectivityChecker>();
+        var orchestrator = new OrchestratorService(
+            getProfiles: () => _profiles,
+            getActiveProfile: () => _profiles.First(),
+            switchProfile: _ => Task.CompletedTask,
+            getTargetsPath: () => Path.Combine(_tempDir, "targets.txt"),
+            notifyScoreUpdate: (_, _) => Task.CompletedTask,
+            connectivity: connectivityMock.Object);
+
+        orchestrator.RestoreRankedProfiles(
+        [
+            (_profiles[0], 100),
+            (_profiles[1], 100)
+        ],
+        preferredProfileFileName: _profiles[1].FileName);
+
+        Assert.Same(_profiles[1], orchestrator.BestRankedProfile);
+        Assert.Equal(100, orchestrator.BestRankedScore);
+    }
+
     // ── Прогресс-репорт при сканировании ──
 
     [Fact]

--- a/FluxRoute.Core/Services/OrchestratorService.cs
+++ b/FluxRoute.Core/Services/OrchestratorService.cs
@@ -94,13 +94,16 @@ public sealed class OrchestratorService : IDisposable
     /// Восстанавливает кэш рейтинга из сохранённых настроек.
     /// Если рейтинг не пустой — при следующем Start() сканирование будет пропущено.
     /// </summary>
-    public void RestoreRankedProfiles(IEnumerable<(ProfileItem profile, int score)> saved)
+    public void RestoreRankedProfiles(
+        IEnumerable<(ProfileItem profile, int score)> saved,
+        string? preferredProfileFileName = null)
     {
-        _rankedProfiles = saved
+        _preferredProfileFileName = preferredProfileFileName;
+        var restored = saved
             .Where(x => x.score > 0)
             .Select(x => (x.profile, x.score, (ProfileProbeResult?)null))
-            .OrderByDescending(x => x.score)
             .ToList();
+        _rankedProfiles = RankProfiles(restored);
         if (_rankedProfiles.Count > 0)
             Notify($"📋 Рейтинг стратегий восстановлен из кэша ({_rankedProfiles.Count} шт.), сканирование пропущено.");
     }

--- a/FluxRoute.Core/Services/OrchestratorService.cs
+++ b/FluxRoute.Core/Services/OrchestratorService.cs
@@ -22,7 +22,14 @@ public sealed class OrchestratorService : IDisposable
     public bool IsScanning { get; private set; }
     public DateTimeOffset? NextCheckAt { get; private set; }
 
+    public ProfileItem? BestRankedProfile =>
+        _rankedProfiles.FirstOrDefault(x => x.score > 0).profile;
+
+    public int BestRankedScore =>
+        _rankedProfiles.FirstOrDefault(x => x.score > 0).score;
+
     private List<(ProfileItem profile, int score, ProfileProbeResult? result)> _rankedProfiles = [];
+    private string? _preferredProfileFileName;
 
     private readonly Func<IEnumerable<ProfileItem>> _getProfiles;
     private readonly Func<ProfileItem?> _getActiveProfile;
@@ -159,6 +166,7 @@ public sealed class OrchestratorService : IDisposable
             }
 
             Notify($"Сканирование {profiles.Count} стратегий с проверкой winws.exe и целей...");
+            _preferredProfileFileName = _getActiveProfile()?.FileName;
             var targets = BuildTargets();
             var scores = new List<(ProfileItem profile, int score, ProfileProbeResult? result)>();
 
@@ -196,7 +204,7 @@ public sealed class OrchestratorService : IDisposable
                 await _notifyScoreUpdate(profile.FileName, result.Score).ConfigureAwait(false);
             }
 
-            _rankedProfiles = scores.OrderByDescending(x => x.score).ToList();
+            _rankedProfiles = RankProfiles(scores);
             var summary = string.Join(", ", _rankedProfiles.Take(3).Select(x => $"{x.profile.DisplayName}:{x.score}%"));
             Notify($"✅ Сканирование завершено.\nТоп: {summary}");
         }
@@ -341,7 +349,20 @@ public sealed class OrchestratorService : IDisposable
         }
         if (!updated)
             _rankedProfiles.Add((profile, score, result));
-        _rankedProfiles = _rankedProfiles.OrderByDescending(x => x.score).ToList();
+        _rankedProfiles = RankProfiles(_rankedProfiles);
+    }
+
+    private List<(ProfileItem profile, int score, ProfileProbeResult? result)> RankProfiles(
+        IEnumerable<(ProfileItem profile, int score, ProfileProbeResult? result)> entries)
+    {
+        return entries
+            .OrderByDescending(x => x.score)
+            .ThenByDescending(x => x.result?.ProcessStable ?? false)
+            .ThenByDescending(x => x.result?.SuccessRate ?? 0)
+            .ThenByDescending(x => _preferredProfileFileName is not null &&
+                                   string.Equals(x.profile.FileName, _preferredProfileFileName, StringComparison.OrdinalIgnoreCase))
+            .ThenBy(x => x.profile.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
     }
 
     private static bool IsSameProfile(ProfileItem? a, ProfileItem? b)

--- a/FluxRoute/Services/TrayPopupService.cs
+++ b/FluxRoute/Services/TrayPopupService.cs
@@ -31,7 +31,7 @@ public sealed class TrayPopupService : ITrayPopupService
             exitApplication: RequestExitApplication,
             restartProtection: RequestRestartProtection)
         {
-            Version = $"v{typeof(App).Assembly.GetName().Version?.ToString(3) ?? "1.7.0"}"
+            Version = $"v{typeof(App).Assembly.GetName().Version?.ToString(3) ?? "1.7.1"}"
         };
     }
 

--- a/FluxRoute/ViewModels/MainViewModel.Orchestrator.cs
+++ b/FluxRoute/ViewModels/MainViewModel.Orchestrator.cs
@@ -810,19 +810,16 @@ public partial class MainViewModel
             ScanTimeRemaining = "✅ Завершено";
             SaveSettings();
 
-            var top = ProfileScores.FirstOrDefault(s => s.Score > 0);
-            ScanBestStrategyText = top is null
+            var bestProfile = _orchestrator.BestRankedProfile;
+            var bestScore = _orchestrator.BestRankedScore;
+            ScanBestStrategyText = bestProfile is null
                 ? "Рабочая стратегия не найдена"
-                : $"{top.DisplayName} · {top.ScoreText}";
-            if (top is not null)
+                : $"{bestProfile.DisplayName} · {bestScore}%";
+            if (bestProfile is not null)
             {
-                var profile = Profiles.FirstOrDefault(p => p.FileName == top.FileName);
-                if (profile is not null)
-                {
-                    AddOrchestratorLog($"[{DateTime.Now:HH:mm:ss}] ▶ Запуск лучшей стратегии «{profile.DisplayName}» ({(int)System.Math.Round((double)top.Score * 100)}%).");
-                    Logs.Add($"[Оркестратор] Лучшая стратегия после сканирования: «{profile.DisplayName}».");
-                    await SwitchProfileAsync(profile).ConfigureAwait(false);
-                }
+                AddOrchestratorLog($"[{DateTime.Now:HH:mm:ss}] ▶ Запуск лучшей стратегии «{bestProfile.DisplayName}» ({bestScore}%).");
+                Logs.Add($"[Оркестратор] Лучшая стратегия после сканирования: «{bestProfile.DisplayName}».");
+                await SwitchProfileAsync(bestProfile).ConfigureAwait(false);
             }
             else if (wasRunning && SelectedProfile is not null && !IsTrackedProcessRunning())
                 await EnsureProtectionRunningAsync().ConfigureAwait(false);

--- a/FluxRoute/ViewModels/MainViewModel.cs
+++ b/FluxRoute/ViewModels/MainViewModel.cs
@@ -1243,7 +1243,7 @@ public partial class MainViewModel : ObservableObject
                 .Select(r => (profile: Profiles.FirstOrDefault(p => p.FileName == r.FileName), r.Score))
                 .Where(x => x.profile is not null)
                 .Select(x => (x.profile!, x.Score));
-            _orchestrator.RestoreRankedProfiles(saved);
+            _orchestrator.RestoreRankedProfiles(saved, settings.LastProfileFileName);
         }
 
         _aiOrchestrator = new AiOrchestratorService(


### PR DESCRIPTION
## Цель PR

Исправить выбор стратегии после полного сканирования, когда несколько профилей получают одинаковый процент совместимости.

## Проблема

Ранее UI выбирал первый профиль из `ProfileScores`. При одинаковом результате это зависело от порядка/имени файла и могло заменить вручную проверенный рабочий ALT на ALT9, хотя базовая проверка показывала одинаковые `100%`. Кроме того, предпочтение активного профиля терялось после перезапуска приложения.

## Что изменено

- оркестратор отдаёт фактически ранжированный профиль-победитель;
- при равном балле учитываются стабильность `winws.exe`, успешность проверок и активный профиль до начала сканирования;
- задержка больше не используется как самостоятельная причина заменить рабочую стратегию;
- UI запускает победителя из рейтинга оркестратора, а не первый элемент UI-списка;
- предпочтительный профиль передаётся при восстановлении кэша из `LastProfileFileName`, поэтому выбор сохраняется после перезапуска;
- добавлен регрессионный тест на равные рейтинги;
- обновлён резервный fallback версии приложения до `1.7.1`.

## Проверка

- локально: 349 тестов успешно, 0 ошибок;
- новый тест `RestoreRankedProfiles_EqualScores_PrefersPersistedProfile` проходит;
- сборка WPF-проекта успешна;
- CI предыдущего коммита проходил успешно, новый запуск ожидается после push.

## Ограничения и следующий шаг

Этот PR не добавляет DPI-suite Flowseal и не проверяет реальную работу Discord/YouTube на уровне приложения. DPI-проверка остаётся отдельной задачей.