### PR TITLE
fix(update): корректно обрабатывать shutdown при автообновлении

### DIFF
--- a/FluxRoute/ViewModels/MainViewModel.cs
+++ b/FluxRoute/ViewModels/MainViewModel.cs
@@ -23,9 +23,9 @@ namespace FluxRoute.ViewModels;
 
 public partial class MainViewModel : ObservableObject
 {
-    public bool IsUpdateShutdownRequested { get; private set; }
+    public bool IsApplicationShutdownRequested { get; private set; }
 
-    public void RequestUpdateShutdown() => IsUpdateShutdownRequested = true;
+    public void RequestApplicationShutdown() => IsApplicationShutdownRequested = true;
 
     // ── Коллекции ──
     public ObservableCollection<string> Logs { get; } = new();
@@ -395,6 +395,7 @@ public partial class MainViewModel : ObservableObject
                 "Отмена",
                 isDanger: true))
         {
+            RequestApplicationShutdown();
             Application.Current.Shutdown();
         }
     }
@@ -403,7 +404,11 @@ public partial class MainViewModel : ObservableObject
     /// Внешний метод для MainWindow — устанавливает флаг подтверждённого закрытия.
     /// Вызывается из OnTrayExitRequested.
     /// </summary>
-    public void ConfirmClose() => Application.Current.Shutdown();
+    public void ConfirmClose()
+    {
+        RequestApplicationShutdown();
+        Application.Current.Shutdown();
+    }
 
     // ── События ──
     public event EventHandler? OpenSettingsRequested;
@@ -1151,7 +1156,7 @@ public partial class MainViewModel : ObservableObject
             refreshDiagnostics: RefreshDiagnostics,
             addAppLog: msg => Logs.Add(msg),
             addRecentLog: AddToRecentLogs,
-            requestUpdateShutdown: RequestUpdateShutdown);
+            requestApplicationShutdown: RequestApplicationShutdown);
 
         Diagnostics.PropertyChanged += (_, e) => OnPropertyChanged(e.PropertyName);
         Service.PropertyChanged += (_, e) =>

--- a/FluxRoute/ViewModels/MainViewModel.cs
+++ b/FluxRoute/ViewModels/MainViewModel.cs
@@ -23,6 +23,10 @@ namespace FluxRoute.ViewModels;
 
 public partial class MainViewModel : ObservableObject
 {
+    public bool IsUpdateShutdownRequested { get; private set; }
+
+    public void RequestUpdateShutdown() => IsUpdateShutdownRequested = true;
+
     // ── Коллекции ──
     public ObservableCollection<string> Logs { get; } = new();
     public ObservableCollection<ProfileItem> Profiles { get; } = new();
@@ -1146,7 +1150,8 @@ public partial class MainViewModel : ObservableObject
             loadProfiles: LoadProfiles,
             refreshDiagnostics: RefreshDiagnostics,
             addAppLog: msg => Logs.Add(msg),
-            addRecentLog: AddToRecentLogs);
+            addRecentLog: AddToRecentLogs,
+            requestUpdateShutdown: RequestUpdateShutdown);
 
         Diagnostics.PropertyChanged += (_, e) => OnPropertyChanged(e.PropertyName);
         Service.PropertyChanged += (_, e) =>

--- a/FluxRoute/ViewModels/UpdatesViewModel.cs
+++ b/FluxRoute/ViewModels/UpdatesViewModel.cs
@@ -27,7 +27,7 @@ public sealed partial class UpdatesViewModel : ObservableObject
     private readonly Action _refreshDiagnostics;
     private readonly Action<string> _addAppLog;
     private readonly Action<string> _addRecentLog;
-    private readonly Action _requestUpdateShutdown;
+    private readonly Action _requestApplicationShutdown;
 
     private UpdateInfo? _pendingUpdate;
     private AppUpdateInfo? _pendingAppUpdate;
@@ -61,7 +61,7 @@ public sealed partial class UpdatesViewModel : ObservableObject
         Action refreshDiagnostics,
         Action<string> addAppLog,
         Action<string> addRecentLog,
-        Action requestUpdateShutdown)
+        Action requestApplicationShutdown)
     {
         _updater = updater;
         _appUpdater = appUpdater;
@@ -74,7 +74,7 @@ public sealed partial class UpdatesViewModel : ObservableObject
         _refreshDiagnostics = refreshDiagnostics;
         _addAppLog = addAppLog;
         _addRecentLog = addRecentLog;
-        _requestUpdateShutdown = requestUpdateShutdown;
+        _requestApplicationShutdown = requestApplicationShutdown;
 
         CurrentAppVersion = _appUpdater.GetCurrentVersion();
     }
@@ -327,7 +327,7 @@ public sealed partial class UpdatesViewModel : ObservableObject
         if (success)
         {
             AddLog($"✅ FluxRoute v{update.Version} установлен, перезапуск...");
-            _requestUpdateShutdown();
+            _requestApplicationShutdown();
             Application.Current?.Dispatcher.Invoke(() => Application.Current.Shutdown());
         }
         else

--- a/FluxRoute/ViewModels/UpdatesViewModel.cs
+++ b/FluxRoute/ViewModels/UpdatesViewModel.cs
@@ -27,6 +27,7 @@ public sealed partial class UpdatesViewModel : ObservableObject
     private readonly Action _refreshDiagnostics;
     private readonly Action<string> _addAppLog;
     private readonly Action<string> _addRecentLog;
+    private readonly Action _requestUpdateShutdown;
 
     private UpdateInfo? _pendingUpdate;
     private AppUpdateInfo? _pendingAppUpdate;
@@ -59,7 +60,8 @@ public sealed partial class UpdatesViewModel : ObservableObject
         Action loadProfiles,
         Action refreshDiagnostics,
         Action<string> addAppLog,
-        Action<string> addRecentLog)
+        Action<string> addRecentLog,
+        Action requestUpdateShutdown)
     {
         _updater = updater;
         _appUpdater = appUpdater;
@@ -72,6 +74,7 @@ public sealed partial class UpdatesViewModel : ObservableObject
         _refreshDiagnostics = refreshDiagnostics;
         _addAppLog = addAppLog;
         _addRecentLog = addRecentLog;
+        _requestUpdateShutdown = requestUpdateShutdown;
 
         CurrentAppVersion = _appUpdater.GetCurrentVersion();
     }
@@ -324,6 +327,7 @@ public sealed partial class UpdatesViewModel : ObservableObject
         if (success)
         {
             AddLog($"✅ FluxRoute v{update.Version} установлен, перезапуск...");
+            _requestUpdateShutdown();
             Application.Current?.Dispatcher.Invoke(() => Application.Current.Shutdown());
         }
         else

--- a/FluxRoute/Views/MainWindow.xaml.cs
+++ b/FluxRoute/Views/MainWindow.xaml.cs
@@ -269,7 +269,7 @@ public partial class MainWindow : Window
 
         // Программное закрытие при успешном обновлении не должно попадать
         // под пользовательское подтверждение или сворачивание в трей.
-        if (Dispatcher.HasShutdownStarted)
+        if (_vm.IsUpdateShutdownRequested)
             _isClosingConfirmed = true;
 
         // ═══ v1.6.0: Feature #21 — Крестик сворачивает в трей ═══

--- a/FluxRoute/Views/MainWindow.xaml.cs
+++ b/FluxRoute/Views/MainWindow.xaml.cs
@@ -267,9 +267,9 @@ public partial class MainWindow : Window
     {
         base.OnClosing(e);
 
-        // Программное закрытие при успешном обновлении не должно попадать
-        // под пользовательское подтверждение или сворачивание в трей.
-        if (_vm.IsUpdateShutdownRequested)
+        // Явное закрытие приложения (обновление или подтверждённый выход)
+        // не должно попадать под подтверждение или сворачивание в трей.
+        if (_vm.IsApplicationShutdownRequested)
             _isClosingConfirmed = true;
 
         // ═══ v1.6.0: Feature #21 — Крестик сворачивает в трей ═══


### PR DESCRIPTION
## Что исправлено

Исправлены оба P1-сценария вокруг программного завершения приложения:

1. После успешного обновления Application.Shutdown() мог попасть в close-to-tray и пропустить cleanup.
2. Подтверждённый выход через MainViewModel тоже мог попасть в close-to-tray, оставив winws, WinDivert или TG Proxy запущенными.

## Изменение

- Добавлен единый флаг IsApplicationShutdownRequested для всех подтверждённых программных shutdown-путей.
- Флаг устанавливается перед Application.Shutdown() при обновлении, через ExitApplication и через ConfirmClose.
- MainWindow использует этот флаг и пропускает close-to-tray и повторное подтверждение, сохраняя штатный Stop, Cleanup и ForceKillProcesses.
- Dispatcher.HasShutdownStarted больше не используется для определения причины закрытия.

## Проверка

- Сборка: 0 ошибок.
- Тесты: 348/348.