### PR TITLE
fix: remember admin choice on startup (#85)

### DIFF
--- a/FluxRoute/App.xaml.cs
+++ b/FluxRoute/App.xaml.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Net.Http;
+using System.Diagnostics;
 using System.Security.Principal;
 using System.Windows;
 using FluxRoute.AI.Services;
@@ -45,29 +46,55 @@ public partial class App : Application
 
             Log.Information("FluxRoute application host started. Arguments: {Arguments}", e.Args);
 
+            var settingsService = _host.Services.GetRequiredService<ISettingsService>();
+
             if (!IsRunningAsAdmin())
             {
                 Log.Warning("FluxRoute is running without administrator privileges.");
 
-                // Временно переключаем, чтобы закрытие диалога не завершило приложение.
-                ShutdownMode = ShutdownMode.OnExplicitShutdown;
-
-                var prompt = new AdminPromptWindow();
-                prompt.ShowDialog();
-
-                // Разрешение работать без прав действует только до закрытия приложения.
-                if (!prompt.ContinueWithoutAdmin)
+                var adminSettings = settingsService.Load();
+                if (adminSettings.RememberAdminChoice)
                 {
-                    Log.Information("User declined to continue without administrator privileges.");
-                    Shutdown();
-                    return;
+                    if (adminSettings.AdminChoiceContinueWithout)
+                    {
+                        Log.Information("Admin prompt skipped: user chose to continue without admin (remembered).");
+                    }
+                    else
+                    {
+                        Log.Information("Admin prompt skipped: restarting as admin (remembered).");
+                        RestartAsAdmin();
+                        Shutdown();
+                        return;
+                    }
+                }
+                else
+                {
+                    // Временно переключаем, чтобы закрытие диалога не завершило приложение.
+                    ShutdownMode = ShutdownMode.OnExplicitShutdown;
+
+                    var prompt = new AdminPromptWindow();
+                    prompt.ShowDialog();
+
+                    if (prompt.RememberChoice)
+                    {
+                        adminSettings.RememberAdminChoice = true;
+                        adminSettings.AdminChoiceContinueWithout = prompt.ContinueWithoutAdmin;
+                        settingsService.Save(adminSettings);
+                        Log.Information("Admin choice saved: continueWithout={Choice}", prompt.ContinueWithoutAdmin);
+                    }
+
+                    if (!prompt.ContinueWithoutAdmin)
+                    {
+                        Log.Information("User declined to continue without administrator privileges.");
+                        Shutdown();
+                        return;
+                    }
                 }
             }
 
             ShutdownMode = ShutdownMode.OnMainWindowClose;
 
             // ═══ v1.7.0: Онбординг при первом запуске ═══
-            var settingsService = _host.Services.GetRequiredService<ISettingsService>();
             var settings = settingsService.Load();
 
             // Миграция старых установок: профиль уже был выбран, но ранняя версия
@@ -442,5 +469,26 @@ public partial class App : Application
         using var identity = WindowsIdentity.GetCurrent();
         var principal = new WindowsPrincipal(identity);
         return principal.IsInRole(WindowsBuiltInRole.Administrator);
+    }
+
+    private static void RestartAsAdmin()
+    {
+        try
+        {
+            var exePath = Environment.ProcessPath
+                ?? System.Reflection.Assembly.GetEntryAssembly()?.Location;
+            if (exePath is not null)
+            {
+                Process.Start(new ProcessStartInfo(exePath)
+                {
+                    UseShellExecute = true,
+                    Verb = "runas"
+                });
+            }
+        }
+        catch
+        {
+            // Пользователь отменил UAC
+        }
     }
 }

--- a/FluxRoute/App.xaml.cs
+++ b/FluxRoute/App.xaml.cs
@@ -53,21 +53,30 @@ public partial class App : Application
                 Log.Warning("FluxRoute is running without administrator privileges.");
 
                 var adminSettings = settingsService.Load();
+                var showAdminPrompt = true;
                 if (adminSettings.RememberAdminChoice)
                 {
                     if (adminSettings.AdminChoiceContinueWithout)
                     {
                         Log.Information("Admin prompt skipped: user chose to continue without admin (remembered).");
+                        showAdminPrompt = false;
                     }
                     else
                     {
                         Log.Information("Admin prompt skipped: restarting as admin (remembered).");
-                        RestartAsAdmin();
-                        Shutdown();
-                        return;
+                        if (RestartAsAdmin(e.Args))
+                        {
+                            Shutdown();
+                            return;
+                        }
+
+                        Log.Warning("Remembered administrator elevation failed or was cancelled; showing the admin prompt again.");
+                        adminSettings.RememberAdminChoice = false;
+                        settingsService.Save(adminSettings);
                     }
                 }
-                else
+
+                if (showAdminPrompt)
                 {
                     // Временно переключаем, чтобы закрытие диалога не завершило приложение.
                     ShutdownMode = ShutdownMode.OnExplicitShutdown;
@@ -75,7 +84,7 @@ public partial class App : Application
                     var prompt = new AdminPromptWindow();
                     prompt.ShowDialog();
 
-                    if (prompt.RememberChoice)
+                    if (prompt.ChoiceMade && prompt.RememberChoice)
                     {
                         adminSettings.RememberAdminChoice = true;
                         adminSettings.AdminChoiceContinueWithout = prompt.ContinueWithoutAdmin;
@@ -83,9 +92,9 @@ public partial class App : Application
                         Log.Information("Admin choice saved: continueWithout={Choice}", prompt.ContinueWithoutAdmin);
                     }
 
-                    if (!prompt.ContinueWithoutAdmin)
+                    if (!prompt.ChoiceMade || !prompt.ContinueWithoutAdmin)
                     {
-                        Log.Information("User declined to continue without administrator privileges.");
+                        Log.Information("User did not choose to continue without administrator privileges.");
                         Shutdown();
                         return;
                     }
@@ -471,24 +480,29 @@ public partial class App : Application
         return principal.IsInRole(WindowsBuiltInRole.Administrator);
     }
 
-    private static void RestartAsAdmin()
+    private static bool RestartAsAdmin(string[] arguments)
     {
         try
         {
             var exePath = Environment.ProcessPath
                 ?? System.Reflection.Assembly.GetEntryAssembly()?.Location;
-            if (exePath is not null)
+            if (exePath is null)
+                return false;
+
+            var startInfo = new ProcessStartInfo(exePath)
             {
-                Process.Start(new ProcessStartInfo(exePath)
-                {
-                    UseShellExecute = true,
-                    Verb = "runas"
-                });
-            }
+                UseShellExecute = true,
+                Verb = "runas"
+            };
+            foreach (var argument in arguments)
+                startInfo.ArgumentList.Add(argument);
+
+            return Process.Start(startInfo) is not null;
         }
         catch
         {
-            // Пользователь отменил UAC
+            // Пользователь отменил UAC или новый процесс не удалось запустить.
+            return false;
         }
     }
 }

--- a/FluxRoute/ViewModels/MainViewModel.cs
+++ b/FluxRoute/ViewModels/MainViewModel.cs
@@ -920,6 +920,11 @@ public partial class MainViewModel : ObservableObject
     [ObservableProperty] private bool closeToTray = true;
     partial void OnCloseToTrayChanged(bool value) => SaveSettings();
 
+    // Сохранённый выбор режима работы без прав администратора.
+    [ObservableProperty] private bool rememberAdminChoice;
+    partial void OnRememberAdminChoiceChanged(bool value) => SaveSettings();
+    private bool _adminChoiceContinueWithout = true;
+
     // ═══ v1.6.0: Автозапуск через Планировщик задач ═══
     [ObservableProperty] private bool taskSchedulerAutoStart;
     partial void OnTaskSchedulerAutoStartChanged(bool value)
@@ -1369,6 +1374,8 @@ public partial class MainViewModel : ObservableObject
         SimpleMode = settings.SimpleMode;
         // ═══ v1.6.0: Крестик сворачивает в трей ═══
         CloseToTray = settings.CloseToTray;
+        RememberAdminChoice = settings.RememberAdminChoice;
+        _adminChoiceContinueWithout = settings.AdminChoiceContinueWithout;
         // ═══════════════════════════════════════
         GameFilterProtocol = settings.GameFilterProtocol;
         ShowProfileSwitchWarning = settings.ShowProfileSwitchWarning;
@@ -1455,6 +1462,8 @@ public partial class MainViewModel : ObservableObject
             SimpleMode = SimpleMode,
             // ═══ v1.6.0: Крестик сворачивает в трей ═══
             CloseToTray = CloseToTray,
+            RememberAdminChoice = RememberAdminChoice,
+            AdminChoiceContinueWithout = _adminChoiceContinueWithout,
             // ═══════════════════════════════════════
             GameFilterProtocol = GameFilterProtocol,
             ShowProfileSwitchWarning = ShowProfileSwitchWarning,

--- a/FluxRoute/ViewModels/MainViewModel.cs
+++ b/FluxRoute/ViewModels/MainViewModel.cs
@@ -922,8 +922,20 @@ public partial class MainViewModel : ObservableObject
 
     // Сохранённый выбор режима работы без прав администратора.
     [ObservableProperty] private bool rememberAdminChoice;
-    partial void OnRememberAdminChoiceChanged(bool value) => SaveSettings();
+    partial void OnRememberAdminChoiceChanged(bool value)
+    {
+        if (value)
+            _adminChoiceContinueWithout = !IsRunningAsAdmin();
+        SaveSettings();
+    }
     private bool _adminChoiceContinueWithout = true;
+
+    private static bool IsRunningAsAdmin()
+    {
+        using var identity = System.Security.Principal.WindowsIdentity.GetCurrent();
+        var principal = new System.Security.Principal.WindowsPrincipal(identity);
+        return principal.IsInRole(System.Security.Principal.WindowsBuiltInRole.Administrator);
+    }
 
     // ═══ v1.6.0: Автозапуск через Планировщик задач ═══
     [ObservableProperty] private bool taskSchedulerAutoStart;

--- a/FluxRoute/Views/AdminPromptWindow.xaml
+++ b/FluxRoute/Views/AdminPromptWindow.xaml
@@ -20,7 +20,8 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
-                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
             <!-- Header -->
@@ -38,9 +39,14 @@
                        Text="Вы можете продолжить без прав, но функциональность будет ограничена."/>
 
 
+            <CheckBox x:Name="RememberCheckBox" Grid.Row="3"
+                      Content="Запомнить выбор и больше не спрашивать"
+                      Foreground="#8997AD" FontSize="11"
+                      Margin="0,8,0,0" VerticalAlignment="Center"/>
+
             <!-- Buttons -->
-            <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right"
-                        VerticalAlignment="Bottom" Margin="0,16,0,0">
+            <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right"
+                        VerticalAlignment="Bottom" Margin="0,12,0,0">
                 <Button Content="Продолжить без прав" Click="ContinueButton_Click"
                         FontFamily="Segoe UI" Foreground="#8B949E" Background="Transparent"
                         BorderThickness="1" BorderBrush="#30363D"

--- a/FluxRoute/Views/AdminPromptWindow.xaml.cs
+++ b/FluxRoute/Views/AdminPromptWindow.xaml.cs
@@ -12,6 +12,7 @@ public partial class AdminPromptWindow : Window
     /// При перезапуске окно закрывается и процесс перезапускается от имени администратора.
     /// </summary>
     public bool ContinueWithoutAdmin { get; private set; }
+    public bool ChoiceMade { get; private set; }
 
     public bool RememberChoice => RememberCheckBox.IsChecked == true;
 
@@ -25,14 +26,20 @@ public partial class AdminPromptWindow : Window
         try
         {
             var exePath = Environment.ProcessPath ?? Process.GetCurrentProcess().MainModule?.FileName;
-            if (exePath is not null)
+            if (exePath is null)
+                return;
+
+            var startInfo = new ProcessStartInfo(exePath)
             {
-                Process.Start(new ProcessStartInfo(exePath)
-                {
-                    UseShellExecute = true,
-                    Verb = "runas"
-                });
-            }
+                UseShellExecute = true,
+                Verb = "runas"
+            };
+            var commandLineArgs = Environment.GetCommandLineArgs();
+            for (var i = 1; i < commandLineArgs.Length; i++)
+                startInfo.ArgumentList.Add(commandLineArgs[i]);
+
+            if (Process.Start(startInfo) is null)
+                return;
         }
         catch
         {
@@ -41,12 +48,14 @@ public partial class AdminPromptWindow : Window
         }
 
         // Закрываем диалог — App.OnStartup() вызовет Shutdown()
+        ChoiceMade = true;
         ContinueWithoutAdmin = false;
         Close();
     }
 
     private void ContinueButton_Click(object sender, RoutedEventArgs e)
     {
+        ChoiceMade = true;
         ContinueWithoutAdmin = true;
         Close();
     }

--- a/FluxRoute/Views/AdminPromptWindow.xaml.cs
+++ b/FluxRoute/Views/AdminPromptWindow.xaml.cs
@@ -13,6 +13,8 @@ public partial class AdminPromptWindow : Window
     /// </summary>
     public bool ContinueWithoutAdmin { get; private set; }
 
+    public bool RememberChoice => RememberCheckBox.IsChecked == true;
+
     public AdminPromptWindow()
     {
         InitializeComponent();

--- a/FluxRoute/Views/Tabs/SettingsPage.xaml
+++ b/FluxRoute/Views/Tabs/SettingsPage.xaml
@@ -116,6 +116,10 @@
                                 <CheckBox Content="Использовать планировщик для автозапуска"
                                           IsChecked="{Binding TaskSchedulerAutoStart}"
                                           Margin="0,4" />
+                                <CheckBox Content="Запоминать выбор прав администратора"
+                                          IsChecked="{Binding RememberAdminChoice}"
+                                          ToolTip="Снимите галочку, чтобы при следующем запуске выбрать режим заново."
+                                          Margin="0,4" />
                                 <CheckBox Content="Высокий приоритет автозагрузки"
                                           IsChecked="{Binding HighPriorityStartupEnabled}"
                                           Margin="0,4" />


### PR DESCRIPTION
## Что исправлено

- восстановлено сохранение выбора пользователя о необходимости прав администратора;
- добавлен чекбокс «Запомнить выбор и больше не спрашивать» в окне запроса прав;
- добавлена настройка «Запоминать выбор прав администратора» в приложении;
- снятие этой настройки сбрасывает сохранённый режим, чтобы при следующем запуске выбрать вариант заново;
- настройка автозапуска через Планировщик задач остаётся отдельной и может быть снята/включена повторно;
- при сохранённом выборе окно запроса прав больше не появляется при каждом запуске;
- восстановлен автоматический перезапуск с правами администратора, если такой выбор был сохранён.

## Проверка

- 355/355 тестов пройдены;
- WPF-проект собирается без ошибок.

Fixes #85