### PR TITLE
fix: wait for WinDivert after app update (#83)

### DIFF
--- a/FluxRoute.Updater/Services/AppUpdaterService.cs
+++ b/FluxRoute.Updater/Services/AppUpdaterService.cs
@@ -460,6 +460,33 @@ public class AppUpdaterService : IAppUpdaterService
                     echo [FluxRoute Updater] Устанавливаем v{update.Version} через installer...
                     start "" /wait "{tempInstaller}" /SILENT /NORESTART /CLOSEAPPLICATIONS
                     if errorlevel 1 exit /b 1
+                    echo [FluxRoute Updater] Завершаем дочерние процессы после установки...
+                    taskkill /IM winws.exe /F > nul 2>&1
+                    taskkill /IM WinDivert.exe /F > nul 2>&1
+                    net stop WinDivert > nul 2>&1
+                    echo [FluxRoute Updater] Ожидаем освобождения winws.exe и WinDivert...
+                    set /a wait_winws_count=0
+                    :wait_winws_after_installer
+                    tasklist /FI "IMAGENAME eq winws.exe" | find /I "winws.exe" > nul
+                    if errorlevel 1 goto wait_windivert_after_installer
+                    set /a wait_winws_count+=1
+                    if %wait_winws_count% GEQ 30 goto wait_windivert_after_installer
+                    timeout /t 1 /nobreak > nul
+                    goto wait_winws_after_installer
+
+                    :wait_windivert_after_installer
+                    set /a wait_windivert_count=0
+                    :wait_windivert_state_installer
+                    sc query "WinDivert" > nul 2>&1
+                    if errorlevel 1060 goto windivert_ready_after_installer
+                    sc query "WinDivert" | findstr /I /C:"STOPPED" > nul
+                    if not errorlevel 1 goto windivert_ready_after_installer
+                    set /a wait_windivert_count+=1
+                    if %wait_windivert_count% GEQ 30 goto windivert_ready_after_installer
+                    timeout /t 1 /nobreak > nul
+                    goto wait_windivert_state_installer
+
+                    :windivert_ready_after_installer
                     del /F /Q "{tempInstaller}" > nul 2>&1
                     echo [FluxRoute Updater] Запускаем FluxRoute v{update.Version}...
                     start "" "{installerExePath}"

--- a/FluxRoute.Updater/Services/AppUpdaterService.cs
+++ b/FluxRoute.Updater/Services/AppUpdaterService.cs
@@ -472,7 +472,7 @@ public class AppUpdaterService : IAppUpdaterService
                     if not errorlevel 1 set "winws_running=1"
                     if not defined winws_running goto wait_windivert_after_installer
                     set /a wait_winws_count+=1
-                    if %wait_winws_count% GEQ 30 goto wait_windivert_after_installer
+                    if %wait_winws_count% GEQ 30 goto update_abort_after_installer
                     timeout /t 1 /nobreak > nul
                     goto wait_winws_after_installer
 
@@ -484,10 +484,14 @@ public class AppUpdaterService : IAppUpdaterService
                     sc query "WinDivert" | findstr /I /C:"STOPPED" > nul
                     if not errorlevel 1 goto windivert_ready_after_installer
                     set /a wait_windivert_count+=1
-                    if %wait_windivert_count% GEQ 30 goto windivert_ready_after_installer
+                    if %wait_windivert_count% GEQ 30 goto update_abort_after_installer
                     timeout /t 1 /nobreak > nul
                     goto wait_windivert_state_installer
 
+                    :update_abort_after_installer
+                    echo [FluxRoute Updater] Не удалось полностью остановить winws.exe, winws2.exe или WinDivert. Обновление отменено.
+                    del /F /Q "{tempInstaller}" > nul 2>&1
+                    exit /b 1
                     :windivert_ready_after_installer
                     echo [FluxRoute Updater] Устанавливаем v{update.Version} через installer...
                     start "" /wait "{tempInstaller}" /SILENT /NORESTART /CLOSEAPPLICATIONS
@@ -556,7 +560,7 @@ public class AppUpdaterService : IAppUpdaterService
                 if not errorlevel 1 set "winws_running=1"
                 if not defined winws_running goto wait_windivert_after_update
                 set /a wait_winws_count+=1
-                if %wait_winws_count% GEQ 30 goto wait_windivert_after_update
+                if %wait_winws_count% GEQ 30 goto update_abort_after_update
                 timeout /t 1 /nobreak > nul
                 goto wait_winws_after_update
 
@@ -568,10 +572,15 @@ public class AppUpdaterService : IAppUpdaterService
                 sc query "WinDivert" | findstr /I /C:"STOPPED" > nul
                 if not errorlevel 1 goto windivert_ready_after_update
                 set /a wait_windivert_count+=1
-                if %wait_windivert_count% GEQ 30 goto windivert_ready_after_update
+                if %wait_windivert_count% GEQ 30 goto update_abort_after_update
                 timeout /t 1 /nobreak > nul
                 goto wait_windivert_state
 
+                :update_abort_after_update
+                echo [FluxRoute Updater] Не удалось полностью остановить winws.exe, winws2.exe или WinDivert. Обновление отменено.
+                del /F /Q "{tempZip}" > nul 2>&1
+                rd /S /Q "{tempDir}" > nul 2>&1
+                exit /b 1
                 :windivert_ready_after_update
                 echo [FluxRoute Updater] Устанавливаем v{update.Version}...
                 xcopy /E /Y /I "{extractedSourceDir}\*" "{exeDir}\"

--- a/FluxRoute.Updater/Services/AppUpdaterService.cs
+++ b/FluxRoute.Updater/Services/AppUpdaterService.cs
@@ -520,6 +520,29 @@ public class AppUpdaterService : IAppUpdaterService
                 taskkill /IM winws.exe /F > nul 2>&1
                 taskkill /IM WinDivert.exe /F > nul 2>&1
                 net stop WinDivert > nul 2>&1
+                echo [FluxRoute Updater] Ожидаем освобождения winws.exe и WinDivert...
+                set /a wait_winws_count=0
+                :wait_winws_after_update
+                tasklist /FI "IMAGENAME eq winws.exe" | find /I "winws.exe" > nul
+                if errorlevel 1 goto wait_windivert_after_update
+                set /a wait_winws_count+=1
+                if %wait_winws_count% GEQ 30 goto wait_windivert_after_update
+                timeout /t 1 /nobreak > nul
+                goto wait_winws_after_update
+
+                :wait_windivert_after_update
+                set /a wait_windivert_count=0
+                :wait_windivert_state
+                sc query "WinDivert" > nul 2>&1
+                if errorlevel 1060 goto windivert_ready_after_update
+                sc query "WinDivert" | findstr /I /C:"STOPPED" > nul
+                if not errorlevel 1 goto windivert_ready_after_update
+                set /a wait_windivert_count+=1
+                if %wait_windivert_count% GEQ 30 goto windivert_ready_after_update
+                timeout /t 1 /nobreak > nul
+                goto wait_windivert_state
+
+                :windivert_ready_after_update
                 echo [FluxRoute Updater] Очищаем временные файлы...
                 del /F /Q "{tempZip}" > nul 2>&1
                 rd /S /Q "{tempDir}" > nul 2>&1

--- a/FluxRoute.Updater/Services/AppUpdaterService.cs
+++ b/FluxRoute.Updater/Services/AppUpdaterService.cs
@@ -541,13 +541,6 @@ public class AppUpdaterService : IAppUpdaterService
                     timeout /t 1 /nobreak > nul
                     goto waitloop
                 )
-                echo [FluxRoute Updater] Устанавливаем v{update.Version}...
-                xcopy /E /Y /I "{extractedSourceDir}\*" "{exeDir}\"
-                if errorlevel 1 (
-                    echo [FluxRoute Updater] Ошибка копирования!
-                    pause
-                    exit /b 1
-                )
                 echo [FluxRoute Updater] Завершаем дочерние процессы...
                 taskkill /IM winws.exe /F > nul 2>&1
                 taskkill /IM winws2.exe /F > nul 2>&1
@@ -580,6 +573,13 @@ public class AppUpdaterService : IAppUpdaterService
                 goto wait_windivert_state
 
                 :windivert_ready_after_update
+                echo [FluxRoute Updater] Устанавливаем v{update.Version}...
+                xcopy /E /Y /I "{extractedSourceDir}\*" "{exeDir}\"
+                if errorlevel 1 (
+                    echo [FluxRoute Updater] Ошибка копирования!
+                    pause
+                    exit /b 1
+                )
                 echo [FluxRoute Updater] Очищаем временные файлы...
                 del /F /Q "{tempZip}" > nul 2>&1
                 rd /S /Q "{tempDir}" > nul 2>&1

--- a/FluxRoute.Updater/Services/AppUpdaterService.cs
+++ b/FluxRoute.Updater/Services/AppUpdaterService.cs
@@ -491,6 +491,7 @@ public class AppUpdaterService : IAppUpdaterService
                     :update_abort_after_installer
                     echo [FluxRoute Updater] Не удалось полностью остановить winws.exe, winws2.exe или WinDivert. Обновление отменено.
                     del /F /Q "{tempInstaller}" > nul 2>&1
+                    start "" "{installerExePath}"
                     exit /b 1
                     :windivert_ready_after_installer
                     echo [FluxRoute Updater] Устанавливаем v{update.Version} через installer...
@@ -580,6 +581,7 @@ public class AppUpdaterService : IAppUpdaterService
                 echo [FluxRoute Updater] Не удалось полностью остановить winws.exe, winws2.exe или WinDivert. Обновление отменено.
                 del /F /Q "{tempZip}" > nul 2>&1
                 rd /S /Q "{tempDir}" > nul 2>&1
+                start "" "{newExePath}"
                 exit /b 1
                 :windivert_ready_after_update
                 echo [FluxRoute Updater] Устанавливаем v{update.Version}...

--- a/FluxRoute.Updater/Services/AppUpdaterService.cs
+++ b/FluxRoute.Updater/Services/AppUpdaterService.cs
@@ -457,10 +457,7 @@ public class AppUpdaterService : IAppUpdaterService
                         timeout /t 1 /nobreak > nul
                         goto waitloop
                     )
-                    echo [FluxRoute Updater] Устанавливаем v{update.Version} через installer...
-                    start "" /wait "{tempInstaller}" /SILENT /NORESTART /CLOSEAPPLICATIONS
-                    if errorlevel 1 exit /b 1
-                    echo [FluxRoute Updater] Завершаем дочерние процессы после установки...
+                    echo [FluxRoute Updater] Завершаем дочерние процессы перед установкой...
                     taskkill /IM winws.exe /F > nul 2>&1
                     taskkill /IM winws2.exe /F > nul 2>&1
                     taskkill /IM WinDivert.exe /F > nul 2>&1
@@ -492,6 +489,9 @@ public class AppUpdaterService : IAppUpdaterService
                     goto wait_windivert_state_installer
 
                     :windivert_ready_after_installer
+                    echo [FluxRoute Updater] Устанавливаем v{update.Version} через installer...
+                    start "" /wait "{tempInstaller}" /SILENT /NORESTART /CLOSEAPPLICATIONS
+                    if errorlevel 1 exit /b 1
                     del /F /Q "{tempInstaller}" > nul 2>&1
                     echo [FluxRoute Updater] Запускаем FluxRoute v{update.Version}...
                     start "" "{installerExePath}"

--- a/FluxRoute.Updater/Services/AppUpdaterService.cs
+++ b/FluxRoute.Updater/Services/AppUpdaterService.cs
@@ -462,13 +462,18 @@ public class AppUpdaterService : IAppUpdaterService
                     if errorlevel 1 exit /b 1
                     echo [FluxRoute Updater] Завершаем дочерние процессы после установки...
                     taskkill /IM winws.exe /F > nul 2>&1
+                    taskkill /IM winws2.exe /F > nul 2>&1
                     taskkill /IM WinDivert.exe /F > nul 2>&1
                     net stop WinDivert > nul 2>&1
-                    echo [FluxRoute Updater] Ожидаем освобождения winws.exe и WinDivert...
+                    echo [FluxRoute Updater] Ожидаем освобождения winws.exe, winws2.exe и WinDivert...
                     set /a wait_winws_count=0
                     :wait_winws_after_installer
+                    set "winws_running="
                     tasklist /FI "IMAGENAME eq winws.exe" | find /I "winws.exe" > nul
-                    if errorlevel 1 goto wait_windivert_after_installer
+                    if not errorlevel 1 set "winws_running=1"
+                    tasklist /FI "IMAGENAME eq winws2.exe" | find /I "winws2.exe" > nul
+                    if not errorlevel 1 set "winws_running=1"
+                    if not defined winws_running goto wait_windivert_after_installer
                     set /a wait_winws_count+=1
                     if %wait_winws_count% GEQ 30 goto wait_windivert_after_installer
                     timeout /t 1 /nobreak > nul
@@ -545,13 +550,18 @@ public class AppUpdaterService : IAppUpdaterService
                 )
                 echo [FluxRoute Updater] Завершаем дочерние процессы...
                 taskkill /IM winws.exe /F > nul 2>&1
+                taskkill /IM winws2.exe /F > nul 2>&1
                 taskkill /IM WinDivert.exe /F > nul 2>&1
                 net stop WinDivert > nul 2>&1
-                echo [FluxRoute Updater] Ожидаем освобождения winws.exe и WinDivert...
+                echo [FluxRoute Updater] Ожидаем освобождения winws.exe, winws2.exe и WinDivert...
                 set /a wait_winws_count=0
                 :wait_winws_after_update
+                set "winws_running="
                 tasklist /FI "IMAGENAME eq winws.exe" | find /I "winws.exe" > nul
-                if errorlevel 1 goto wait_windivert_after_update
+                if not errorlevel 1 set "winws_running=1"
+                tasklist /FI "IMAGENAME eq winws2.exe" | find /I "winws2.exe" > nul
+                if not errorlevel 1 set "winws_running=1"
+                if not defined winws_running goto wait_windivert_after_update
                 set /a wait_winws_count+=1
                 if %wait_winws_count% GEQ 30 goto wait_windivert_after_update
                 timeout /t 1 /nobreak > nul

--- a/FluxRoute/ViewModels/MainViewModel.Process.cs
+++ b/FluxRoute/ViewModels/MainViewModel.Process.cs
@@ -510,7 +510,8 @@ public partial class MainViewModel
                 _runStartedAt = null;
                 _runningProcess = null;
                 IsRunning = false;
-                Logs.Add("winws.exe завершился.");
+                var exitCode = SafeExitCode(winws);
+                Logs.Add($"winws.exe завершился (код выхода: {exitCode?.ToString() ?? "неизвестен"}).");
                 AddToRecentLogs("⏹ Завершён");
             }).ConfigureAwait(false);
         }
@@ -609,7 +610,8 @@ public partial class MainViewModel
                 _runStartedAt = null;
                 _runningProcess = null;
                 IsRunning = false;
-                Logs.Add("winws.exe завершился.");
+                var exitCode = winws is null ? (int?)null : SafeExitCode(winws);
+                Logs.Add($"winws.exe завершился (код выхода: {exitCode?.ToString() ?? "неизвестен"}).");
                 AddToRecentLogs("⏹ Завершён");
             }).ConfigureAwait(false);
         }
@@ -743,6 +745,18 @@ public partial class MainViewModel
         }
 
         return pids;
+    }
+
+    private static int? SafeExitCode(Process process)
+    {
+        try
+        {
+            return process.ExitCode;
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private static bool SafeHasExited(Process process)


### PR DESCRIPTION
## Что исправлено

После обновления FluxRoute новый процесс мог запускаться до полного освобождения `winws.exe` и драйвера WinDivert. В результате `winws.exe` запускался, но завершался через несколько секунд.

Изменения:

- updater завершает `winws.exe` и `winws2.exe`;
- portable updater останавливает движки и ждёт WinDivert до копирования payload;
- installer updater останавливает движки и ждёт WinDivert до запуска installer;
- если процессы или WinDivert не остановились за отведённое время, обновление отменяется без копирования и установки;
- после отмены обновления запускается существующий FluxRoute.exe, чтобы приложение не оставалось закрытым;
- добавлен ограниченный таймаут ожидания, чтобы updater не зависал навсегда;
- в лог приложения добавляется код выхода `winws.exe` для диагностики подобных случаев.

## Проверка

- сборка FluxRoute прошла успешно;
- тесты: **355/355**.

Fixes #83