### PR TITLE
fix(ai): расширить мьютекс очистки на эволюцию и стартовый переподбор (release #76)

### DIFF
--- a/FluxRoute.AI/Services/AiOrchestratorService.cs
+++ b/FluxRoute.AI/Services/AiOrchestratorService.cs
@@ -255,6 +255,11 @@ public sealed class AiOrchestratorService : IDisposable
 
     private async Task PickAndApplyInitialAsync(CancellationToken ct)
     {
+        // Мьютекс с purge: стартовый переподбор материализует/применяет генотипы и не должен
+        // выполняться одновременно с очисткой (release #76, P2).
+        await _aiGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
         var fp = _fingerprints.Capture();
         _registry.MarkNetworkSeen(fp.Hash);
         _registry.Save();
@@ -281,6 +286,11 @@ public sealed class AiOrchestratorService : IDisposable
         }
 
         await ApplyGenomeAsync(pick, fp, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _aiGate.Release();
+        }
     }
 
     private async Task RunCycleAsync(CancellationToken ct)
@@ -479,14 +489,24 @@ public sealed class AiOrchestratorService : IDisposable
 
     public async Task EvolveNowAsync(CancellationToken ct = default)
     {
-        SyncBuiltins();
-        var fp = _fingerprints.Capture();
-        var child = await Task.Run(() => _evolver.Evolve(fp), ct).ConfigureAwait(false);
-        await _refreshProfiles().ConfigureAwait(false);
-        if (child is not null)
-            await VerifyEvolvedGenomeAsync(child, fp, ct).ConfigureAwait(false);
-        else
-            Notify("ИИ: эволюция не создала новую стратегию (мало активных родителей или дубликат).");
+        // Мьютекс с purge: явная эволюция материализует/проверяет генотипы и не должна
+        // выполняться одновременно с очисткой (release #76, P2).
+        await _aiGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            SyncBuiltins();
+            var fp = _fingerprints.Capture();
+            var child = await Task.Run(() => _evolver.Evolve(fp), ct).ConfigureAwait(false);
+            await _refreshProfiles().ConfigureAwait(false);
+            if (child is not null)
+                await VerifyEvolvedGenomeAsync(child, fp, ct).ConfigureAwait(false);
+            else
+                Notify("ИИ: эволюция не создала новую стратегию (мало активных родителей или дубликат).");
+        }
+        finally
+        {
+            _aiGate.Release();
+        }
     }
 
     private ProfileItem? ResolveProfile(StrategyGenome g)

--- a/FluxRoute.AI/Services/AiOrchestratorService.cs
+++ b/FluxRoute.AI/Services/AiOrchestratorService.cs
@@ -494,7 +494,10 @@ public sealed class AiOrchestratorService : IDisposable
         await _aiGate.WaitAsync(ct).ConfigureAwait(false);
         try
         {
-            SyncBuiltins();
+            // Полная синхронизация ПОД мьютексом: GarbageCollectEvolved удаляет эволюции и
+            // должен выполняться исключающе с purge/циклом — иначе удалялась бы активная
+            // стратегия, пока цикл работает (правка по ревью PR #94, P2).
+            SyncRegistryFromEngine();
             var fp = _fingerprints.Capture();
             var child = await Task.Run(() => _evolver.Evolve(fp), ct).ConfigureAwait(false);
             await _refreshProfiles().ConfigureAwait(false);

--- a/FluxRoute/ViewModels/MainViewModel.Ai.cs
+++ b/FluxRoute/ViewModels/MainViewModel.Ai.cs
@@ -251,7 +251,8 @@ public partial class MainViewModel
     [RelayCommand]
     private async Task RunAiEvolutionAsync()
     {
-        _aiOrchestrator.SyncRegistryFromEngine();
+        // Синхронизация теперь внутри EvolveNowAsync (под мьютексом): GarbageCollectEvolved
+        // удаляет эволюции и должен выполняться исключающе с purge/циклом (правка по ревью PR #94, P2).
         await _aiOrchestrator.EvolveNowAsync().ConfigureAwait(true);
         var d = Application.Current?.Dispatcher;
         if (d is not null && !d.CheckAccess())


### PR DESCRIPTION
## Цель
Расширить взаимное исключение очистки эволюций на все мутирующие пути ИИ (замечание **P2** из ревью релизного PR **#76**).

## Что входит
- Мьютекс `_aiGate` теперь захватывается также в `EvolveNowAsync` (явная эволюция, включая `SyncRegistryFromEngine`/`GarbageCollectEvolved`) и `PickAndApplyInitialAsync` (стартовый переподбор). Раньше эти пути мутировали генотипы/BAT без исключения с очисткой, и purge мог удалить стратегию, пока она материализовалась/сохранялась.

## Проверка
- `dotnet build FluxRoute.slnx -c Debug` — успешно.
- `dotnet test FluxRoute.slnx -c Debug` — **360/360** тестов зелёные.

## Связанные
- base: `nightly`
- Продолжение #93 (мьютекс purge/циклы), релиз #76 (v1.7.1).