### PR TITLE
fix(ai): сериализовать импорт результатов скана с циклами ИИ (release #76, issue #89)

### DIFF
--- a/FluxRoute.AI/Services/AiOrchestratorService.cs
+++ b/FluxRoute.AI/Services/AiOrchestratorService.cs
@@ -129,6 +129,12 @@ public sealed class AiOrchestratorService : IDisposable
     /// </summary>
     public async Task ProbeSelectedStrategyAsync(CancellationToken ct = default)
     {
+        // Мьютекс с циклами/очисткой: точечная проверка пишет в bandit и реестр, и не должна
+        // выполняться одновременно с фоновым циклом (иначе теряется/портится cooldown-состояние).
+        // Правка по Codex (релизный PR #76, P2).
+        await _aiGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
         var active = _getActiveProfile();
         if (active is null)
         {
@@ -139,14 +145,14 @@ public sealed class AiOrchestratorService : IDisposable
         var genome = FindGenomeForProfile(active);
         if (genome is null)
         {
-            Notify($"ИИ: для «{active.DisplayName}» нет записи генотипа — проверка пропущена.");
+            Notify($@"ИИ: для «{active.DisplayName}» нет записи генотипа — проверка пропущена.");
             return;
         }
 
         var fp = _fingerprints.Capture();
         _registry.MarkNetworkSeen(fp.Hash);
         _registry.Save();
-        Notify($"ИИ: проверка выбранной стратегии «{genome.DisplayName}»...");
+        Notify($@"ИИ: проверка выбранной стратегии «{genome.DisplayName}»...");
         try
         {
             await TryProbeAndPersistGenomeAsync(genome, fp, ct, isFreshlyEvolved: false, autoDeleteBelowThreshold: false)
@@ -158,6 +164,11 @@ public sealed class AiOrchestratorService : IDisposable
             // возвращаем исходный выбранный профиль (правка по Codex P2, десятый раунд).
             if (active is not null && !ReferenceEquals(_getActiveProfile(), active))
                 await _switchProfile(active).ConfigureAwait(false);
+        }
+        }
+        finally
+        {
+            _aiGate.Release();
         }
     }
 
@@ -790,11 +801,18 @@ public sealed class AiOrchestratorService : IDisposable
     /// Сетевой хэш захватывается ДО начала скана и передаётся сюда, чтобы при смене сети
     /// в процессе скана все результаты не были бы помечены новым (а не фактическим) хэшем.
     /// </summary>
-    public void PersistScanVerification(IReadOnlyList<(Guid genomeId, ProfileProbeResult result)> results, string networkHash)
+    public async Task PersistScanVerification(IReadOnlyList<(Guid genomeId, ProfileProbeResult result)> results, string networkHash)
     {
         if (results.Count == 0)
             return;
 
+        // Мьютекс с циклами/очисткой: импорт результатов скана пишет в bandit/историю/реестр и
+        // не должен выполняться одновременно с фоновым циклом, иначе теряется/портится
+        // cooldown-состояние и сохраняются конфликтующие баллы за один генотип.
+        // Правка по Codex (релизный PR #76, P2).
+        await _aiGate.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+        try
+        {
         _registry.MarkNetworkSeen(networkHash);
         var updated = false;
 
@@ -842,6 +860,11 @@ public sealed class AiOrchestratorService : IDisposable
 
         if (updated)
             _registry.Save();
+        }
+        finally
+        {
+            _aiGate.Release();
+        }
     }
 
     private void SyncBuiltins()

--- a/FluxRoute/ViewModels/MainViewModel.Orchestrator.cs
+++ b/FluxRoute/ViewModels/MainViewModel.Orchestrator.cs
@@ -438,7 +438,7 @@ public partial class MainViewModel
     /// проверки, чтобы вкладка ИИ и очистка/подбор видели фактические значения.
     /// Не перезапускает стратегии. <paramref name="networkHash"/> — хэш сети ДО начала скана.
     /// </summary>
-    private void PersistScanScoresIntoGenomes(string networkHash)
+    private async Task PersistScanScoresIntoGenomes(string networkHash)
     {
         try
         {
@@ -456,7 +456,7 @@ public partial class MainViewModel
                 results.Add((g.Id, entry.result));
             }
 
-            _aiOrchestrator.PersistScanVerification(results, networkHash);
+            await _aiOrchestrator.PersistScanVerification(results, networkHash).ConfigureAwait(true);
         }
         catch (Exception ex)
         {
@@ -861,7 +861,7 @@ public partial class MainViewModel
                     // от чужой сети (правка по Codex P1, восьмой раунд). В этом случае не переносим.
                     if (string.Equals(_aiFingerprints.Capture().Hash, scanNetworkHash, StringComparison.Ordinal))
                     {
-                        PersistScanScoresIntoGenomes(scanNetworkHash);
+                        await PersistScanScoresIntoGenomes(scanNetworkHash);
                     }
                     else
                     {


### PR DESCRIPTION
## Цель
Закрыть остаток замечания Codex по релизному PR #76: мьютекс `_aiGate` должен сериализовать **все** пути записи в bandit/реестр, включая импорт результатов полного скана.

## Что входит
- `PersistScanVerification` (перенос результатов полного скана в генотипы/bandit/реестр) теперь захватывает `_aiGate` — раньше он не был под мьютексом и мог гоняться с фоновым циклом ИИ: теряется/портится cooldown-состояние, сохраняются конфликтующие баллы за один генотип.
- `ProbeSelectedStrategyAsync` (точечная проверка) также под `_aiGate` — тот же класс записи в bandit.
- `PersistScanVerification` стал `async Task`; цепочка VM (`PersistScanScoresIntoGenomes`) связана `await`-ом, чтобы не блокировать UI ожиданием цикла.

## Проверка
- `dotnet build FluxRoute.slnx -c Debug` — успешно.
- `dotnet test FluxRoute.slnx -c Debug` — **360/360** зелёные.

## Связанные
- base: `nightly` (релизная линия v1.7.1)
- закрывает остаток P2 по PR #76.
