### PR TITLE
fix(ai): сериализовать целевую эволюцию с очисткой (release #76, issue #89)

### DIFF
--- a/FluxRoute.AI/Services/AiOrchestratorService.cs
+++ b/FluxRoute.AI/Services/AiOrchestratorService.cs
@@ -94,6 +94,27 @@ public sealed class AiOrchestratorService : IDisposable
         _registry.Save();
     }
 
+    /// <summary>
+    /// Выполняет операцию под тем же мьютексом, что циклы ИИ, очистка и эволюция.
+    /// Нужен путям, которые мутируют генотипы/материализуют BAT в обход оркестратора
+    /// (например, целевая эволюция кнопки «Подобрать стратегию»): иначе purge может удалить
+    /// или снять с регистрации ту же стратегию, пока она создаётся, и BAT с реестром
+    /// разойдутся (release #76, P2).
+    /// </summary>
+    public async Task<T> RunSerializedAsync<T>(Func<Task<T>> operation, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        await _aiGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            return await operation().ConfigureAwait(false);
+        }
+        finally
+        {
+            _aiGate.Release();
+        }
+    }
+
     public void Start()
     {
         if (_cts is not null)

--- a/FluxRoute/ViewModels/MainViewModel.Ai.cs
+++ b/FluxRoute/ViewModels/MainViewModel.Ai.cs
@@ -163,22 +163,35 @@ public partial class MainViewModel
                 Logs.Add($"[🧠] Ни одна стратегия не дала Score > 70%, запускаю эволюцию.");
 
                 var fp = _aiFingerprints.Capture();
-                var child = await Task.Run(() => _evolver.Evolve(fp));
-                if (child is not null)
+
+                // Эволюция + синхронизация реестра + запись .bat — под тем же мьютексом, что
+                // очистка и циклы ИИ. Иначе purge может удалить или снять с регистрации ту же
+                // стратегию, пока она создаётся и материализуется, и BAT с реестром разойдутся
+                // (release #76, P2). Обновление UI/профилей — уже вне мьютекса.
+                var child = await _aiOrchestrator.RunSerializedAsync(async () =>
                 {
+                    var evolved = await Task.Run(() => _evolver.Evolve(fp));
+                    if (evolved is null)
+                        return evolved;
+
                     _aiOrchestrator.SyncRegistryFromEngine();
-                    await RefreshProfilesInternalAsync();
 
                     // Материализуем .bat файл
                     var evolvedDir = Path.Combine(EngineDir, "ai-evolved");
                     Directory.CreateDirectory(evolvedDir);
-                    var batPath = Path.Combine(evolvedDir, $"{child.DisplayName}.bat");
+                    var batPath = Path.Combine(evolvedDir, $"{evolved.DisplayName}.bat");
                     if (!File.Exists(batPath))
                     {
                         var materializer = new FluxRoute.AI.Services.BatMaterializer();
-                        materializer.WriteBat(child, EngineDir);
+                        materializer.WriteBat(evolved, EngineDir);
                     }
 
+                    return evolved;
+                });
+
+                if (child is not null)
+                {
+                    await RefreshProfilesInternalAsync();
                     LoadProfiles();
                     RebuildAiStrategyRows();
 


### PR DESCRIPTION
## Что и зачем

Закрывает P2 из ревью Codex на релизный PR #76 («Gate purge against target-specific evolution»).

Целевая эволюция кнопки **«Подобрать стратегию»** (`MainViewModel.Ai.cs`) вызывала `_evolver.Evolve` и `SyncRegistryFromEngine` **напрямую**, минуя мьютекс `_aiGate`. Если пользователь запускал подбор, а затем очистку (`PurgeWeakEvolutionsAsync`) до завершения подбора, `IsScanning` оставался `false`, и purge мог удалить/снять с регистрации ту же эволюцию, пока она создаётся, — файлы `.bat` и реестр расходились.

## Что изменено

**Изменено**
- `FluxRoute.AI/Services/AiOrchestratorService.cs` — добавлен публичный хелпер `RunSerializedAsync<T>(Func<Task<T>>, CancellationToken)`: выполняет произвольную операцию под тем же мьютексом `_aiGate`, что циклы ИИ, очистка и эволюция.
- `FluxRoute/ViewModels/MainViewModel.Ai.cs` — целевая эволюция, `SyncRegistryFromEngine()` и материализация `.bat` обёрнуты в `RunSerializedAsync`; обновление профилей/UI (`RefreshProfilesInternalAsync`, `LoadProfiles`, `RebuildAiStrategyRows`) выполняется уже вне мьютекса.

## Тесты

- `dotnet test FluxRoute.slnx -c Debug` — **360/360** пройдено, 0 не пройдено.
- Новых замечаний по сборке нет.

## Связанное

- Включается в релизный PR #76 (v1.7.1).
- Продолжает класс фиксов сериализации: #93 (мьютекс purge ∨ циклы), #94 (эволюция/стартовый переподбор), #95 (импорт скана и точечная проверка).