### PR TITLE
fix(ai): сериализовать полный скан с импортом результатов (release #76, issue #89)

### DIFF
--- a/FluxRoute.AI/FluxRoute.AI.csproj
+++ b/FluxRoute.AI/FluxRoute.AI.csproj
@@ -14,4 +14,10 @@
     <ProjectReference Include="..\FluxRoute.Core\FluxRoute.Core.csproj" />
   </ItemGroup>
 
+  <!-- Тестам нужен доступ к отслеживаемому генотипу ИИ, чтобы проверять согласование
+       состояния после внешней смены профиля (ревью #97, P1). -->
+  <ItemGroup>
+    <InternalsVisibleTo Include="FluxRoute.Core.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/FluxRoute.AI/Services/AiOrchestratorService.cs
+++ b/FluxRoute.AI/Services/AiOrchestratorService.cs
@@ -217,9 +217,13 @@ public sealed class AiOrchestratorService : IDisposable
         _registry.GetGenomes().FirstOrDefault(g => GenomeMatchesProfile(g, profile));
 
     /// <summary>
-    /// Сопоставление генотипа профилю по тем же признакам, что и в <see cref="FindGenomeForProfile"/>:
-    /// файл BAT, отображаемое имя, исходный путь. Пустые значения совпадением НЕ считаются — иначе
-    /// профиль без имени «подошёл» бы любому генотипу без имени.
+    /// Сопоставление генотипа профилю. Если путь BAT известен с ОБЕИХ сторон, решает только он:
+    /// одноимённые встроенный и ai-evolved BAT — это разные стратегии (<c>LoadProfiles</c> при
+    /// совпадении имён отдаёт предпочтение evolved-пути, MainViewModel.Diagnostics.cs), поэтому принять
+    /// чужой генотип по имени файла нельзя — результат проверки уйдёт в историю и бандит под чужим Id
+    /// (правка по Codex P1, ревью #97). Путь известен лишь с одной стороны — сопоставляем по файлу,
+    /// отображаемому имени и исходному пути, как раньше. Пустые значения совпадением НЕ считаются:
+    /// иначе профиль без имени «подошёл» бы любому генотипу без имени.
     /// </summary>
     public static bool GenomeMatchesProfile(StrategyGenome genome, ProfileItem profile)
     {
@@ -230,9 +234,27 @@ public sealed class AiOrchestratorService : IDisposable
             !string.IsNullOrWhiteSpace(left) &&
             string.Equals(left, right, StringComparison.OrdinalIgnoreCase);
 
+        var genomePath = NormalizeBatPath(genome.SourceBatPath);
+        var profilePath = NormalizeBatPath(profile.FullPath);
+        if (genomePath.Length > 0 && profilePath.Length > 0)
+            return string.Equals(genomePath, profilePath, StringComparison.OrdinalIgnoreCase);
+
         return Same(genome.BatFileName, profile.FileName)
             || Same(genome.DisplayName, profile.DisplayName)
             || Same(genome.SourceBatPath, profile.FullPath);
+    }
+
+    /// <summary>
+    /// Путь BAT к единому виду для сравнения: без пробелов, с одинаковыми разделителями и без
+    /// хвостового разделителя. Файловая система не опрашивается — путь может быть сетевым или
+    /// недоступным, а сравнение должно оставаться чистой функцией.
+    /// </summary>
+    private static string NormalizeBatPath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return string.Empty;
+
+        return path.Trim().Replace('/', '\\').TrimEnd('\\');
     }
 
     /// <summary>

--- a/FluxRoute.AI/Services/AiOrchestratorService.cs
+++ b/FluxRoute.AI/Services/AiOrchestratorService.cs
@@ -282,15 +282,24 @@ public sealed class AiOrchestratorService : IDisposable
         if (genome.Origin != StrategyOrigin.Evolved)
             return;
 
-        if (!string.IsNullOrEmpty(genome.SourceBatPath) && File.Exists(genome.SourceBatPath))
-            return;
-
         if (string.IsNullOrEmpty(genome.BatFileName))
             return;
 
-        var path = Path.Combine(_engineDir(), "ai-evolved", genome.BatFileName);
-        if (File.Exists(path))
-            StoreBatPath(genome, path);
+        // ═══ Канонический путь evolved-стратегии — ТЕКУЩАЯ папка engine\ai-evolved, а не любой
+        // существующий файл: при копировании портативной установки старая папка остаётся доступной,
+        // и проверка «сохранённый путь ещё жив» навсегда закрепляла бы генотип за старой копией.
+        // Тогда живой профиль новой установки считался бы чужим — проверка выбранной стратегии
+        // пропускалась, а согласование сбрасывало генотип (правка по Codex P2, ревью #97).
+        var current = Path.Combine(_engineDir(), "ai-evolved", genome.BatFileName);
+        if (File.Exists(current))
+        {
+            StoreBatPath(genome, current);
+            return;
+        }
+
+        // Файла в текущей установке нет — оставляем сохранённый путь, если он ещё жив.
+        if (!string.IsNullOrEmpty(genome.SourceBatPath) && File.Exists(genome.SourceBatPath))
+            return;
     }
 
     /// <summary>
@@ -701,6 +710,11 @@ public sealed class AiOrchestratorService : IDisposable
     private ProfileItem? ResolveProfile(StrategyGenome g)
     {
         var engineDir = _engineDir();
+
+        // Сначала подтягиваем канонический путь BAT: при копировании портативной установки сохранённый
+        // абсолютный путь ведёт в старую папку, а профили грузятся из новой — запускать надо тот файл,
+        // который видит текущая установка (правка по Codex P2, ревью #97).
+        RefreshStaleBatPath(g);
 
         string? path = null;
         if (!string.IsNullOrEmpty(g.SourceBatPath) && File.Exists(g.SourceBatPath))

--- a/FluxRoute.AI/Services/AiOrchestratorService.cs
+++ b/FluxRoute.AI/Services/AiOrchestratorService.cs
@@ -214,10 +214,55 @@ public sealed class AiOrchestratorService : IDisposable
     /// Находит генотип, соответствующий выбранному профилю (по имени bat/отображаемому имени/пути).
     /// </summary>
     private StrategyGenome? FindGenomeForProfile(ProfileItem profile) =>
-        _registry.GetGenomes().FirstOrDefault(g =>
-            string.Equals(g.BatFileName, profile.FileName, StringComparison.OrdinalIgnoreCase)
-            || string.Equals(g.DisplayName, profile.DisplayName, StringComparison.OrdinalIgnoreCase)
-            || string.Equals(g.SourceBatPath, profile.FullPath, StringComparison.OrdinalIgnoreCase));
+        _registry.GetGenomes().FirstOrDefault(g => GenomeMatchesProfile(g, profile));
+
+    /// <summary>
+    /// Сопоставление генотипа профилю по тем же признакам, что и в <see cref="FindGenomeForProfile"/>:
+    /// файл BAT, отображаемое имя, исходный путь. Пустые значения совпадением НЕ считаются — иначе
+    /// профиль без имени «подошёл» бы любому генотипу без имени.
+    /// </summary>
+    public static bool GenomeMatchesProfile(StrategyGenome genome, ProfileItem profile)
+    {
+        ArgumentNullException.ThrowIfNull(genome);
+        ArgumentNullException.ThrowIfNull(profile);
+
+        static bool Same(string? left, string? right) =>
+            !string.IsNullOrWhiteSpace(left) &&
+            string.Equals(left, right, StringComparison.OrdinalIgnoreCase);
+
+        return Same(genome.BatFileName, profile.FileName)
+            || Same(genome.DisplayName, profile.DisplayName)
+            || Same(genome.SourceBatPath, profile.FullPath);
+    }
+
+    /// <summary>
+    /// Согласует отслеживаемый генотип с профилем, который реально работает. Вызывается под УЖЕ
+    /// удержанным мьютексом <see cref="_aiGate"/> после внешней смены профиля (полный скан запустил
+    /// лучшую стратегию): следующий цикл проверяет НОВЫЙ профиль, и если <c>_currentGenome</c> остался
+    /// от прежнего, результат проверки уйдёт в историю и бандит под чужим Id — состояние разъедется
+    /// (правка по Codex P1, ревью #97).
+    /// </summary>
+    /// <returns><c>true</c>, если отслеживаемый генотип сброшен.</returns>
+    public bool ReconcileGenomeWithActiveProfile()
+    {
+        if (_currentGenome is null)
+            return false;
+
+        var active = _getActiveProfile();
+        if (active is not null && GenomeMatchesProfile(_currentGenome, active))
+            return false;
+
+        _currentGenome = null;
+        Notify("ИИ: активный профиль изменён вне ИИ — отслеживаемая стратегия сброшена, подбор на следующем цикле.");
+        return true;
+    }
+
+    /// <summary>Отслеживаемый генотип — для тестов согласования состояния (ревью #97, P1).</summary>
+    internal StrategyGenome? CurrentGenomeForTests
+    {
+        get => _currentGenome;
+        set => _currentGenome = value;
+    }
 
     /// <summary>
     /// Полное сканирование всех включённых стратегий ИИ с сохранением результатов проверки.

--- a/FluxRoute.AI/Services/AiOrchestratorService.cs
+++ b/FluxRoute.AI/Services/AiOrchestratorService.cs
@@ -253,6 +253,10 @@ public sealed class AiOrchestratorService : IDisposable
             return false;
 
         _currentGenome = null;
+        // Счётчик неудач относился к прежнему генотипу: если его не обнулить, первая же неудачная
+        // проверка новой стратегии добьёт унаследованную серию и её снимут раньше, чем она получит
+        // положенное число попыток (как и в обычной ветке смены стратегии) — Codex P2, ревью #97.
+        _consecutiveFailures = 0;
         Notify("ИИ: активный профиль изменён вне ИИ — отслеживаемая стратегия сброшена, подбор на следующем цикле.");
         return true;
     }
@@ -262,6 +266,13 @@ public sealed class AiOrchestratorService : IDisposable
     {
         get => _currentGenome;
         set => _currentGenome = value;
+    }
+
+    /// <summary>Серия неудач по отслеживаемому генотипу — для тестов согласования (ревью #97, P2).</summary>
+    internal int ConsecutiveFailuresForTests
+    {
+        get => _consecutiveFailures;
+        set => _consecutiveFailures = value;
     }
 
     /// <summary>
@@ -415,6 +426,9 @@ public sealed class AiOrchestratorService : IDisposable
             {
                 Notify("ИИ: текущая стратегия отключена, переподбор...");
                 _currentGenome = null;
+                // Серия неудач относилась к снятой стратегии — иначе следующая получила бы
+                // унаследованный счётчик и была бы снята раньше положенного (Codex P2, ревью #97).
+                _consecutiveFailures = 0;
                 await RepickAfterNetworkChangeAsync(fp, ct).ConfigureAwait(false);
                 return;
             }

--- a/FluxRoute.AI/Services/AiOrchestratorService.cs
+++ b/FluxRoute.AI/Services/AiOrchestratorService.cs
@@ -212,9 +212,21 @@ public sealed class AiOrchestratorService : IDisposable
 
     /// <summary>
     /// Находит генотип, соответствующий выбранному профилю (по имени bat/отображаемому имени/пути).
+    /// Сначала прямое сопоставление; если не нашлось — у генотипов мог устареть сохранённый путь
+    /// (переезд портативной установки), пути подтягиваются и сопоставление повторяется.
     /// </summary>
-    private StrategyGenome? FindGenomeForProfile(ProfileItem profile) =>
-        _registry.GetGenomes().FirstOrDefault(g => GenomeMatchesProfile(g, profile));
+    private StrategyGenome? FindGenomeForProfile(ProfileItem profile)
+    {
+        var genomes = _registry.GetGenomes();
+        var match = genomes.FirstOrDefault(g => GenomeMatchesProfile(g, profile));
+        if (match is not null)
+            return match;
+
+        foreach (var g in genomes)
+            RefreshStaleBatPath(g);
+
+        return _registry.GetGenomes().FirstOrDefault(g => GenomeMatchesProfile(g, profile));
+    }
 
     /// <summary>
     /// Сопоставление генотипа профилю. Если путь BAT известен с ОБЕИХ сторон, решает только он:
@@ -258,6 +270,46 @@ public sealed class AiOrchestratorService : IDisposable
     }
 
     /// <summary>
+    /// Подтягивает устаревший путь BAT у генотипа: портативная установка могла переехать, и в реестре
+    /// остаётся прежний абсолютный путь, хотя файл лежит в текущей папке <c>engine\ai-evolved</c>.
+    /// Без этого сопоставление «генотип ↔ профиль» по пути сочло бы свой же генотип чужим (Codex P2, ревью #97).
+    /// </summary>
+    private void RefreshStaleBatPath(StrategyGenome genome)
+    {
+        // Лечим только эволюционированные стратегии: их BAT лежит в engine\ai-evolved и опознаётся по
+        // имени файла, тогда как встроенные заново регистрируются SyncBuiltins по актуальному пути,
+        // и подмена пути встроенного генотипа на одноимённый evolved-BAT была бы ошибкой.
+        if (genome.Origin != StrategyOrigin.Evolved)
+            return;
+
+        if (!string.IsNullOrEmpty(genome.SourceBatPath) && File.Exists(genome.SourceBatPath))
+            return;
+
+        if (string.IsNullOrEmpty(genome.BatFileName))
+            return;
+
+        var path = Path.Combine(_engineDir(), "ai-evolved", genome.BatFileName);
+        if (File.Exists(path))
+            StoreBatPath(genome, path);
+    }
+
+    /// <summary>
+    /// Записывает актуальный путь BAT в генотип и реестр, если он отличается от сохранённого.
+    /// </summary>
+    private void StoreBatPath(StrategyGenome genome, string path)
+    {
+        var fileName = Path.GetFileName(path);
+        if (string.Equals(genome.SourceBatPath, path, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(genome.BatFileName, fileName, StringComparison.OrdinalIgnoreCase))
+            return;
+
+        genome.SourceBatPath = path;
+        genome.BatFileName = fileName;
+        _registry.Upsert(genome);
+        _registry.Save();
+    }
+
+    /// <summary>
     /// Согласует отслеживаемый генотип с профилем, который реально работает. Вызывается под УЖЕ
     /// удержанным мьютексом <see cref="_aiGate"/> после внешней смены профиля (полный скан запустил
     /// лучшую стратегию): следующий цикл проверяет НОВЫЙ профиль, и если <c>_currentGenome</c> остался
@@ -269,6 +321,10 @@ public sealed class AiOrchestratorService : IDisposable
     {
         if (_currentGenome is null)
             return false;
+
+        // Путь в реестре мог устареть при переезде портативной установки — иначе сравнение по пути
+        // сочло бы свой же генотип чужим и сбросило его без причины (Codex P2, ревью #97).
+        RefreshStaleBatPath(_currentGenome);
 
         var active = _getActiveProfile();
         if (active is not null && GenomeMatchesProfile(_currentGenome, active))
@@ -653,21 +709,17 @@ public sealed class AiOrchestratorService : IDisposable
         {
             path = Path.Combine(engineDir, "ai-evolved", g.BatFileName);
             if (!File.Exists(path))
-            {
                 path = _materializer.WriteBat(g, engineDir);
-                g.SourceBatPath = path;
-                g.BatFileName = Path.GetFileName(path);
-                _registry.Upsert(g);
-                _registry.Save();
-            }
+
+            // Найденный по имени файла путь мог отличаться от сохранённого (переезд портативной
+            // установки) — реестр надо освежить, иначе генотип перестанет сопоставляться со своим
+            // профилем (Codex P2, ревью #97).
+            StoreBatPath(g, path);
         }
         else if (g.Origin == StrategyOrigin.Evolved)
         {
             path = _materializer.WriteBat(g, engineDir);
-            g.SourceBatPath = path;
-            g.BatFileName = Path.GetFileName(path);
-            _registry.Upsert(g);
-            _registry.Save();
+            StoreBatPath(g, path);
         }
 
         if (path is null || !File.Exists(path))

--- a/FluxRoute.AI/Services/AiOrchestratorService.cs
+++ b/FluxRoute.AI/Services/AiOrchestratorService.cs
@@ -303,6 +303,27 @@ public sealed class AiOrchestratorService : IDisposable
     }
 
     /// <summary>
+    /// Ищет существующий BAT генотипа. Встроенная стратегия живёт в корне <c>engine</c>, эволюционированная —
+    /// в <c>engine\ai-evolved</c>; подставлять встроенной одноимённый evolved-файл нельзя — это другая
+    /// стратегия, и закреплённый за встроенным генотипом путь сделал бы его «владельцем» живого профиля
+    /// (Codex P2, ревью #97). Материализацию из полей делает вызывающий.
+    /// </summary>
+    internal static string? FindExistingBatPath(StrategyGenome g, string engineDir)
+    {
+        if (!string.IsNullOrEmpty(g.SourceBatPath) && File.Exists(g.SourceBatPath))
+            return g.SourceBatPath;
+
+        if (string.IsNullOrEmpty(g.BatFileName))
+            return null;
+
+        var candidate = g.Origin == StrategyOrigin.Builtin
+            ? Path.Combine(engineDir, g.BatFileName)
+            : Path.Combine(engineDir, "ai-evolved", g.BatFileName);
+
+        return File.Exists(candidate) ? candidate : null;
+    }
+
+    /// <summary>
     /// Записывает актуальный путь BAT в генотип и реестр, если он отличается от сохранённого.
     /// </summary>
     private void StoreBatPath(StrategyGenome genome, string path)
@@ -716,25 +737,16 @@ public sealed class AiOrchestratorService : IDisposable
         // который видит текущая установка (правка по Codex P2, ревью #97).
         RefreshStaleBatPath(g);
 
-        string? path = null;
-        if (!string.IsNullOrEmpty(g.SourceBatPath) && File.Exists(g.SourceBatPath))
-            path = g.SourceBatPath;
-        else if (!string.IsNullOrEmpty(g.BatFileName))
-        {
-            path = Path.Combine(engineDir, "ai-evolved", g.BatFileName);
-            if (!File.Exists(path))
-                path = _materializer.WriteBat(g, engineDir);
+        string? path = FindExistingBatPath(g, engineDir);
 
-            // Найденный по имени файла путь мог отличаться от сохранённого (переезд портативной
-            // установки) — реестр надо освежить, иначе генотип перестанет сопоставляться со своим
-            // профилем (Codex P2, ревью #97).
-            StoreBatPath(g, path);
-        }
-        else if (g.Origin == StrategyOrigin.Evolved)
-        {
+        // Материализация из полей генотипа — только для эволюционированных: восстановленный BAT
+        // пишется в engine\ai-evolved, а встроенную стратегию туда «переселять» нельзя
+        // (правка по Codex P2, ревью #97).
+        if (path is null && g.Origin == StrategyOrigin.Evolved)
             path = _materializer.WriteBat(g, engineDir);
+
+        if (path is not null && File.Exists(path))
             StoreBatPath(g, path);
-        }
 
         if (path is null || !File.Exists(path))
             return null;

--- a/FluxRoute.AI/Services/AiOrchestratorService.cs
+++ b/FluxRoute.AI/Services/AiOrchestratorService.cs
@@ -115,6 +115,23 @@ public sealed class AiOrchestratorService : IDisposable
         }
     }
 
+    /// <summary>
+    /// То же, что <see cref="RunSerializedAsync{T}"/>, но для операции без результата.
+    /// </summary>
+    public async Task RunSerializedAsync(Func<Task> operation, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+        await _aiGate.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await operation().ConfigureAwait(false);
+        }
+        finally
+        {
+            _aiGate.Release();
+        }
+    }
+
     public void Start()
     {
         if (_cts is not null)
@@ -834,6 +851,29 @@ public sealed class AiOrchestratorService : IDisposable
         await _aiGate.WaitAsync(CancellationToken.None).ConfigureAwait(false);
         try
         {
+            ApplyScanResults(results, networkHash);
+        }
+        finally
+        {
+            _aiGate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Ядро переноса результатов уже выполненного полного сканирования в генотипы: пишет
+    /// LastVerificationScore/LastVerifiedAt, а также сетевой outcome в историю и bandit-реестр по
+    /// реальным данным проверки (ProcessStable/SuccessRate/FailedChecks), а не реконструируя их из
+    /// композитного счёта. Сетевой хэш захватывается ДО начала скана и передаётся сюда, чтобы при
+    /// смене сети в процессе скана результаты не были помечены новым (а не фактическим) хэшем.
+    /// НЕ захватывает <c>_aiGate</c>: вызывающий обязан держать мьютекс, чтобы между измерением
+    /// профилей и записью результата не вклинился фоновый цикл ИИ — сериализовать нужно весь
+    /// скан-и-импорт целиком, а не только запись (релизный PR #76, P2).
+    /// </summary>
+    public void ApplyScanResults(IReadOnlyList<(Guid genomeId, ProfileProbeResult result)> results, string networkHash)
+    {
+        if (results.Count == 0)
+            return;
+
         _registry.MarkNetworkSeen(networkHash);
         var updated = false;
 
@@ -881,11 +921,6 @@ public sealed class AiOrchestratorService : IDisposable
 
         if (updated)
             _registry.Save();
-        }
-        finally
-        {
-            _aiGate.Release();
-        }
     }
 
     private void SyncBuiltins()

--- a/FluxRoute.Core.Tests/AiOrchestratorBatPathTests.cs
+++ b/FluxRoute.Core.Tests/AiOrchestratorBatPathTests.cs
@@ -1,0 +1,101 @@
+using System.IO;
+using FluxRoute.AI.Models;
+using FluxRoute.AI.Services;
+
+namespace FluxRoute.Core.Tests;
+
+/// <summary>
+/// Тесты поиска BAT для генотипа (issue #89, релиз v1.7.1). Встроенная стратегия живёт в корне engine,
+/// эволюционированная — в engine\ai-evolved. Раньше фолбэк по имени файла подставлял встроенному
+/// генотипу одноимённый evolved-BAT, и путь эволюционированной стратегии закреплялся за встроенным
+/// генотипом: согласование считало встроенный генотип владельцем живого профиля, а проверки и
+/// результаты бандита записывались под чужим Id (правка по Codex P2, ревью #97).
+/// </summary>
+public sealed class AiOrchestratorBatPathTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly string _engineDir;
+    private readonly string _evolvedDir;
+
+    public AiOrchestratorBatPathTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"FluxRouteBatPathTests_{Guid.NewGuid():N}");
+        _engineDir = Path.Combine(_tempDir, "engine");
+        _evolvedDir = Path.Combine(_engineDir, "ai-evolved");
+        Directory.CreateDirectory(_evolvedDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void FindExistingBatPath_PrefersStoredPath_WhenItExists()
+    {
+        var stored = CreateBat(_evolvedDir, "evolved_v1.bat");
+        var genome = Genome("evolved_v1.bat", "evolved_v1", stored, StrategyOrigin.Evolved);
+
+        Assert.Equal(stored, AiOrchestratorService.FindExistingBatPath(genome, _engineDir));
+    }
+
+    [Fact]
+    public void FindExistingBatPath_DoesNotAdoptEvolvedBat_ForBuiltinGenome()
+    {
+        // Ключевой случай: у встроенного генотипа сохранённый путь устарел, а в ai-evolved лежит файл
+        // с тем же именем. Это ДРУГАЯ стратегия — встроенному генотипу её путь не принадлежит.
+        CreateBat(_evolvedDir, "general.bat");
+        var genome = Genome("general.bat", "general", @"C:\СтароеМесто\engine\general.bat");
+
+        Assert.Null(AiOrchestratorService.FindExistingBatPath(genome, _engineDir));
+    }
+
+    [Fact]
+    public void FindExistingBatPath_UsesEngineRoot_ForBuiltinGenome()
+    {
+        var builtin = CreateBat(_engineDir, "general.bat");
+        CreateBat(_evolvedDir, "general.bat");
+        var genome = Genome("general.bat", "general", @"C:\СтароеМесто\engine\general.bat");
+
+        Assert.Equal(builtin, AiOrchestratorService.FindExistingBatPath(genome, _engineDir));
+    }
+
+    [Fact]
+    public void FindExistingBatPath_UsesEvolvedFolder_ForEvolvedGenome()
+    {
+        var evolved = CreateBat(_evolvedDir, "FR-ev-42.bat");
+        var genome = Genome("FR-ev-42.bat", "FR-ev-42", null, StrategyOrigin.Evolved);
+
+        Assert.Equal(evolved, AiOrchestratorService.FindExistingBatPath(genome, _engineDir));
+    }
+
+    [Fact]
+    public void FindExistingBatPath_ReturnsNull_WhenNothingIsFound()
+    {
+        Assert.Null(AiOrchestratorService.FindExistingBatPath(
+            Genome("more.bat", "more", null, StrategyOrigin.Evolved), _engineDir));
+        Assert.Null(AiOrchestratorService.FindExistingBatPath(
+            Genome(null, "more", null, StrategyOrigin.Evolved), _engineDir));
+        Assert.Null(AiOrchestratorService.FindExistingBatPath(
+            Genome(null, "builtin", @"C:\СтароеМесто\engine\builtin.bat"), _engineDir));
+    }
+
+    private string CreateBat(string dir, string fileName)
+    {
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, fileName);
+        File.WriteAllText(path, "@echo off");
+        return path;
+    }
+
+    private static StrategyGenome Genome(string? batFileName, string displayName, string? sourceBatPath,
+        StrategyOrigin origin = StrategyOrigin.Builtin) =>
+        new()
+        {
+            BatFileName = batFileName,
+            DisplayName = displayName,
+            SourceBatPath = sourceBatPath,
+            Origin = origin,
+            OrchestratorEnabled = true,
+        };
+}

--- a/FluxRoute.Core.Tests/AiOrchestratorGenomeReconcileTests.cs
+++ b/FluxRoute.Core.Tests/AiOrchestratorGenomeReconcileTests.cs
@@ -17,6 +17,7 @@ namespace FluxRoute.Core.Tests;
 public sealed class AiOrchestratorGenomeReconcileTests : IDisposable
 {
     private readonly string _tempDir;
+    private readonly string _engineDir;
     private readonly AiStrategyRegistry _registry;
     private readonly AiOrchestratorService _service;
     private ProfileItem? _activeProfile;
@@ -27,6 +28,7 @@ public sealed class AiOrchestratorGenomeReconcileTests : IDisposable
         Directory.CreateDirectory(_tempDir);
         var engineDir = Path.Combine(_tempDir, "engine");
         Directory.CreateDirectory(engineDir);
+        _engineDir = engineDir;
 
         _registry = new AiStrategyRegistry(Path.Combine(_tempDir, "registry.json"));
         var history = new AiHistoryStore(Path.Combine(_tempDir, "fluxroute-ai-history.jsonl"));
@@ -79,14 +81,56 @@ public sealed class AiOrchestratorGenomeReconcileTests : IDisposable
     private static ProfileItem Profile(string fileName, string displayName, string fullPath) =>
         new() { FileName = fileName, DisplayName = displayName, FullPath = fullPath };
 
-    private static StrategyGenome Genome(string? batFileName, string displayName, string? sourceBatPath) =>
+    private static StrategyGenome Genome(string? batFileName, string displayName, string? sourceBatPath,
+        StrategyOrigin origin = StrategyOrigin.Builtin) =>
         new()
         {
             BatFileName = batFileName,
             DisplayName = displayName,
             SourceBatPath = sourceBatPath,
+            Origin = origin,
             OrchestratorEnabled = true,
         };
+
+    [Fact]
+    public void ReconcileGenomeWithActiveProfile_RefreshesStaleBatPath_WhenPortableInstallMoved()
+    {
+        var evolvedDir = Path.Combine(_engineDir, "ai-evolved");
+        Directory.CreateDirectory(evolvedDir);
+        var evolvedBat = Path.Combine(evolvedDir, "evolved_v1.bat");
+        File.WriteAllText(evolvedBat, "@echo off");
+
+        // Установка переехала: в реестре остался прежний абсолютный путь к тому же BAT.
+        var genome = Genome("evolved_v1.bat", "evolved_v1",
+            @"C:\СтароеМесто\engine\ai-evolved\evolved_v1.bat", StrategyOrigin.Evolved);
+        _service.CurrentGenomeForTests = genome;
+        _activeProfile = Profile("evolved_v1.bat", "evolved_v1", evolvedBat);
+
+        var reset = _service.ReconcileGenomeWithActiveProfile();
+
+        // Это своя же стратегия — генотип сохраняется, а устаревший путь подтягивается из ai-evolved.
+        Assert.False(reset);
+        Assert.Same(genome, _service.CurrentGenomeForTests);
+        Assert.Equal(evolvedBat, genome.SourceBatPath);
+    }
+
+    [Fact]
+    public void ReconcileGenomeWithActiveProfile_DoesNotAdoptEvolvedBat_ForBuiltinGenome()
+    {
+        var evolvedDir = Path.Combine(_engineDir, "ai-evolved");
+        Directory.CreateDirectory(evolvedDir);
+        var evolvedBat = Path.Combine(evolvedDir, "general.bat");
+        File.WriteAllText(evolvedBat, "@echo off");
+
+        // Одноимённый evolved-BAT не «усыновляется» встроенным генотипом: у встроенных канонический
+        // путь — engine\<имя>, и заново регистрирует их SyncBuiltins.
+        _service.CurrentGenomeForTests = Genome("general.bat", "general",
+            @"C:\СтароеМесто\engine\general.bat");
+        _activeProfile = Profile("general.bat", "general", evolvedBat);
+
+        Assert.True(_service.ReconcileGenomeWithActiveProfile());
+        Assert.Null(_service.CurrentGenomeForTests);
+    }
 
     [Fact]
     public void GenomeMatchesProfile_MatchesByBatFile_DisplayName_OrSourcePath()

--- a/FluxRoute.Core.Tests/AiOrchestratorGenomeReconcileTests.cs
+++ b/FluxRoute.Core.Tests/AiOrchestratorGenomeReconcileTests.cs
@@ -125,12 +125,15 @@ public sealed class AiOrchestratorGenomeReconcileTests : IDisposable
     {
         var genome = Genome("general.bat", "general", @"C:\engine\general.bat");
         _service.CurrentGenomeForTests = genome;
+        _service.ConsecutiveFailuresForTests = 1;
         _activeProfile = Profile("general.bat", "general", @"C:\engine\general.bat");
 
         var reset = _service.ReconcileGenomeWithActiveProfile();
 
         Assert.False(reset);
         Assert.Same(genome, _service.CurrentGenomeForTests);
+        // Свой профиль остался — серия неудач по нему сохраняется.
+        Assert.Equal(1, _service.ConsecutiveFailuresForTests);
     }
 
     [Fact]
@@ -138,6 +141,7 @@ public sealed class AiOrchestratorGenomeReconcileTests : IDisposable
     {
         var genome = Genome("general.bat", "general", @"C:\engine\general.bat");
         _service.CurrentGenomeForTests = genome;
+        _service.ConsecutiveFailuresForTests = 2;
         // Скан выбрал и запустил другую стратегию — отслеживаемый генотип больше не соответствует
         // рабочему профилю и должен быть сброшен, иначе результат уйдёт под старым Id.
         _activeProfile = Profile("evolved_v1.bat", "evolved_v1", @"C:\engine\ai-evolved\evolved_v1.bat");
@@ -146,6 +150,9 @@ public sealed class AiOrchestratorGenomeReconcileTests : IDisposable
 
         Assert.True(reset);
         Assert.Null(_service.CurrentGenomeForTests);
+        // Серия неудач относилась к прежнему генотипу: новая стратегия не должна быть снята
+        // после первой же осечки из-за унаследованного счётчика (Codex P2, ревью #97).
+        Assert.Equal(0, _service.ConsecutiveFailuresForTests);
     }
 
     [Fact]

--- a/FluxRoute.Core.Tests/AiOrchestratorGenomeReconcileTests.cs
+++ b/FluxRoute.Core.Tests/AiOrchestratorGenomeReconcileTests.cs
@@ -1,0 +1,172 @@
+using System.IO;
+using FluxRoute.AI.Models;
+using FluxRoute.AI.Services;
+using FluxRoute.Core.Models;
+using FluxRoute.Core.Services;
+using Moq;
+
+namespace FluxRoute.Core.Tests;
+
+/// <summary>
+/// Тесты согласования отслеживаемого генотипа ИИ с рабочим профилем (issue #89, релиз v1.7.1).
+/// Полный скан останавливает последний проверенный профиль, но оставляет его выбранным, а затем
+/// запускает лучшую стратегию. Если после такого переключения оставить прежний _currentGenome,
+/// следующий цикл проверит НОВЫЙ профиль, а результат запишет в историю/бандит под чужим Id
+/// (правка по Codex P1, ревью #97).
+/// </summary>
+public sealed class AiOrchestratorGenomeReconcileTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly AiStrategyRegistry _registry;
+    private readonly AiOrchestratorService _service;
+    private ProfileItem? _activeProfile;
+
+    public AiOrchestratorGenomeReconcileTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"FluxRouteReconcileTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        var engineDir = Path.Combine(_tempDir, "engine");
+        Directory.CreateDirectory(engineDir);
+
+        _registry = new AiStrategyRegistry(Path.Combine(_tempDir, "registry.json"));
+        var history = new AiHistoryStore(Path.Combine(_tempDir, "fluxroute-ai-history.jsonl"));
+
+        var connectivityMock = new Mock<IConnectivityChecker>();
+        connectivityMock
+            .Setup(c => c.CheckAllAsync(
+                It.IsAny<IEnumerable<TargetEntry>>(),
+                It.IsAny<bool>(),
+                It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((1.0, new List<CheckResult>()));
+
+        var fingerprints = new NetworkFingerprintProvider();
+        var materializer = new BatMaterializer();
+        var bandit = new BanditSelector(_registry, new Random(12345));
+        var evolver = new StrategyEvolver(
+            _registry,
+            history,
+            materializer,
+            () => engineDir,
+            () => new AiSettings());
+
+        _service = new AiOrchestratorService(
+            getProfiles: () => new List<ProfileItem>(),
+            getActiveProfile: () => _activeProfile,
+            switchProfile: _ => Task.CompletedTask,
+            getTargetsPath: () => "",
+            notifyScoreUpdate: (_, _) => Task.CompletedTask,
+            engineDir: () => engineDir,
+            () => new AiSettings(),
+            refreshProfiles: () => Task.CompletedTask,
+            isWinwsRunning: () => false,
+            ensureProtectionRunning: () => Task.CompletedTask,
+            connectivityMock.Object,
+            fingerprints,
+            new NetworkChangeWatcher(fingerprints),
+            _registry,
+            history,
+            bandit,
+            evolver,
+            materializer);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+    }
+
+    private static ProfileItem Profile(string fileName, string displayName, string fullPath) =>
+        new() { FileName = fileName, DisplayName = displayName, FullPath = fullPath };
+
+    private static StrategyGenome Genome(string? batFileName, string displayName, string? sourceBatPath) =>
+        new()
+        {
+            BatFileName = batFileName,
+            DisplayName = displayName,
+            SourceBatPath = sourceBatPath,
+            OrchestratorEnabled = true,
+        };
+
+    [Fact]
+    public void GenomeMatchesProfile_MatchesByBatFile_DisplayName_OrSourcePath()
+    {
+        var profile = Profile("general.bat", "general", @"C:\engine\general.bat");
+
+        Assert.True(AiOrchestratorService.GenomeMatchesProfile(
+            Genome("general.bat", "другое имя", null), profile));
+        Assert.True(AiOrchestratorService.GenomeMatchesProfile(
+            Genome(null, "GENERAL", null), profile));
+        Assert.True(AiOrchestratorService.GenomeMatchesProfile(
+            Genome(null, "другое имя", @"c:\ENGINE\GENERAL.BAT"), profile));
+    }
+
+    [Fact]
+    public void GenomeMatchesProfile_DoesNotMatchDifferentProfile()
+    {
+        var profile = Profile("general.bat", "general", @"C:\engine\general.bat");
+
+        Assert.False(AiOrchestratorService.GenomeMatchesProfile(
+            Genome("evolved_v1.bat", "evolved_v1", @"C:\engine\ai-evolved\evolved_v1.bat"), profile));
+    }
+
+    [Fact]
+    public void GenomeMatchesProfile_IgnoresEmptyValues()
+    {
+        // Профиль без имени и пути не должен «подходить» генотипу без имени и пути.
+        var profile = Profile("", "", "");
+
+        Assert.False(AiOrchestratorService.GenomeMatchesProfile(Genome(null, "", null), profile));
+        Assert.False(AiOrchestratorService.GenomeMatchesProfile(Genome("   ", "  ", "  "), profile));
+    }
+
+    [Fact]
+    public void ReconcileGenomeWithActiveProfile_KeepsGenome_WhenActiveProfileMatches()
+    {
+        var genome = Genome("general.bat", "general", @"C:\engine\general.bat");
+        _service.CurrentGenomeForTests = genome;
+        _activeProfile = Profile("general.bat", "general", @"C:\engine\general.bat");
+
+        var reset = _service.ReconcileGenomeWithActiveProfile();
+
+        Assert.False(reset);
+        Assert.Same(genome, _service.CurrentGenomeForTests);
+    }
+
+    [Fact]
+    public void ReconcileGenomeWithActiveProfile_ResetsGenome_WhenBestProfileIsAnotherStrategy()
+    {
+        var genome = Genome("general.bat", "general", @"C:\engine\general.bat");
+        _service.CurrentGenomeForTests = genome;
+        // Скан выбрал и запустил другую стратегию — отслеживаемый генотип больше не соответствует
+        // рабочему профилю и должен быть сброшен, иначе результат уйдёт под старым Id.
+        _activeProfile = Profile("evolved_v1.bat", "evolved_v1", @"C:\engine\ai-evolved\evolved_v1.bat");
+
+        var reset = _service.ReconcileGenomeWithActiveProfile();
+
+        Assert.True(reset);
+        Assert.Null(_service.CurrentGenomeForTests);
+    }
+
+    [Fact]
+    public void ReconcileGenomeWithActiveProfile_ResetsGenome_WhenNoProfileIsActive()
+    {
+        _service.CurrentGenomeForTests = Genome("general.bat", "general", @"C:\engine\general.bat");
+        _activeProfile = null;
+
+        var reset = _service.ReconcileGenomeWithActiveProfile();
+
+        Assert.True(reset);
+        Assert.Null(_service.CurrentGenomeForTests);
+    }
+
+    [Fact]
+    public void ReconcileGenomeWithActiveProfile_ReturnsFalse_WhenNothingIsTracked()
+    {
+        _service.CurrentGenomeForTests = null;
+        _activeProfile = Profile("general.bat", "general", @"C:\engine\general.bat");
+
+        Assert.False(_service.ReconcileGenomeWithActiveProfile());
+        Assert.Null(_service.CurrentGenomeForTests);
+    }
+}

--- a/FluxRoute.Core.Tests/AiOrchestratorGenomeReconcileTests.cs
+++ b/FluxRoute.Core.Tests/AiOrchestratorGenomeReconcileTests.cs
@@ -115,6 +115,33 @@ public sealed class AiOrchestratorGenomeReconcileTests : IDisposable
     }
 
     [Fact]
+    public void ReconcileGenomeWithActiveProfile_PrefersCurrentEnginePath_WhenOldCopyStillExists()
+    {
+        var evolvedDir = Path.Combine(_engineDir, "ai-evolved");
+        Directory.CreateDirectory(evolvedDir);
+        var currentBat = Path.Combine(evolvedDir, "evolved_v2.bat");
+        File.WriteAllText(currentBat, "@echo off");
+
+        // Установку скопировали, старая папка осталась доступной: сохранённый путь существует, но ведёт
+        // в прошлую копию. Канонический путь evolved-стратегии — текущая engine\ai-evolved, иначе живой
+        // профиль новой установки считался бы чужим (правка по Codex P2, ревью #97).
+        var oldDir = Path.Combine(_tempDir, "старая-копия", "ai-evolved");
+        Directory.CreateDirectory(oldDir);
+        var oldBat = Path.Combine(oldDir, "evolved_v2.bat");
+        File.WriteAllText(oldBat, "@echo off");
+
+        var genome = Genome("evolved_v2.bat", "evolved_v2", oldBat, StrategyOrigin.Evolved);
+        _service.CurrentGenomeForTests = genome;
+        _activeProfile = Profile("evolved_v2.bat", "evolved_v2", currentBat);
+
+        var reset = _service.ReconcileGenomeWithActiveProfile();
+
+        Assert.False(reset);
+        Assert.Same(genome, _service.CurrentGenomeForTests);
+        Assert.Equal(currentBat, genome.SourceBatPath);
+    }
+
+    [Fact]
     public void ReconcileGenomeWithActiveProfile_DoesNotAdoptEvolvedBat_ForBuiltinGenome()
     {
         var evolvedDir = Path.Combine(_engineDir, "ai-evolved");

--- a/FluxRoute.Core.Tests/AiOrchestratorGenomeReconcileTests.cs
+++ b/FluxRoute.Core.Tests/AiOrchestratorGenomeReconcileTests.cs
@@ -121,6 +121,54 @@ public sealed class AiOrchestratorGenomeReconcileTests : IDisposable
     }
 
     [Fact]
+    public void GenomeMatchesProfile_DistinguishesSameNameBuiltinAndEvolvedBat()
+    {
+        // LoadProfiles при совпадении имён отдаёт предпочтение ai-evolved-пути: одноимённые BAT —
+        // РАЗНЫЕ стратегии, поэтому чужой генотип нельзя принять по имени (Codex P1, ревью #97).
+        var evolvedProfile = Profile("general.bat", "general", @"C:\engine\ai-evolved\general.bat");
+
+        Assert.False(AiOrchestratorService.GenomeMatchesProfile(
+            Genome("general.bat", "general", @"C:\engine\general.bat"), evolvedProfile));
+    }
+
+    [Fact]
+    public void GenomeMatchesProfile_FallsBackToName_WhenPathIsKnownOnOneSideOnly()
+    {
+        var profile = Profile("general.bat", "general", @"C:\engine\ai-evolved\general.bat");
+
+        // У генотипа путь не записан (исходный BAT неизвестен) — решает имя файла.
+        Assert.True(AiOrchestratorService.GenomeMatchesProfile(
+            Genome("general.bat", "general", null), profile));
+    }
+
+    [Fact]
+    public void GenomeMatchesProfile_NormalizesSeparatorsAndCase_InPathComparison()
+    {
+        var profile = Profile("evolved_v1.bat", "evolved_v1", @"C:\engine\ai-evolved\evolved_v1.bat");
+
+        Assert.True(AiOrchestratorService.GenomeMatchesProfile(
+            Genome("evolved_v1.bat", "evolved_v1", @"C:/ENGINE/AI-EVOLVED/EVOLVED_V1.BAT"), profile));
+        Assert.True(AiOrchestratorService.GenomeMatchesProfile(
+            Genome("evolved_v1.bat", "evolved_v1", @"   C:\engine\ai-evolved\evolved_v1.bat   "), profile));
+    }
+
+    [Fact]
+    public void ReconcileGenomeWithActiveProfile_ResetsGenome_WhenSameNameEvolvedPathIsActive()
+    {
+        _service.CurrentGenomeForTests = Genome("general.bat", "general", @"C:\engine\general.bat");
+        _service.ConsecutiveFailuresForTests = 1;
+        // Скан запустил ai-evolved BAT с тем же именем: генотип встроенной стратегии уже не подходит,
+        // иначе результат проверившегося профиля записался бы под Id встроенного генотипа.
+        _activeProfile = Profile("general.bat", "general", @"C:\engine\ai-evolved\general.bat");
+
+        var reset = _service.ReconcileGenomeWithActiveProfile();
+
+        Assert.True(reset);
+        Assert.Null(_service.CurrentGenomeForTests);
+        Assert.Equal(0, _service.ConsecutiveFailuresForTests);
+    }
+
+    [Fact]
     public void ReconcileGenomeWithActiveProfile_KeepsGenome_WhenActiveProfileMatches()
     {
         var genome = Genome("general.bat", "general", @"C:\engine\general.bat");

--- a/FluxRoute.Core.Tests/AiOrchestratorPurgeTests.cs
+++ b/FluxRoute.Core.Tests/AiOrchestratorPurgeTests.cs
@@ -189,8 +189,10 @@ public sealed class AiOrchestratorPurgeTests : IDisposable
         var builtin = AddBuiltin("general", 90);
         var weak = AddEvolved("evolved_v1", 30);
 
-        // «Сканировать все стратегии» переносит результаты в историю/геном через PersistScanVerification.
-        _service.PersistScanVerification(
+        // «Сканировать все стратегии» переносит результаты в историю/геном через PersistScanVerification
+        // (gated-обёртка). Вызов обязательно дожидаемся: импорт асинхронный, иначе purge успел бы
+        // отработать до записи наблюдений и тест стал бы флаки.
+        await _service.PersistScanVerification(
             new[]
             {
                 (builtin.Id, new ProfileProbeResult { Score = 90, SuccessRate = 0.9, ProcessStable = true }),
@@ -199,6 +201,34 @@ public sealed class AiOrchestratorPurgeTests : IDisposable
             _fingerprints.Capture().Hash);
 
         // После этого очистка должна найти кандидата и удалить его (защита #62 соблюдена: builtin ок).
+        var deleted = await _service.PurgeWeakEvolutionsAsync();
+
+        Assert.Equal(1, deleted);
+        Assert.Null(_registry.GetById(weak.Id));
+    }
+
+    [Fact]
+    public async Task ApplyScanResults_UnderSerializedScanGate_RecordsOutcome_SoPurgeFindsCandidate()
+    {
+        var builtin = AddBuiltin("general", 90);
+        var weak = AddEvolved("evolved_v1", 30);
+
+        // Production-путь «Сканировать все стратегии»: полный скан и импорт его результатов идут под
+        // ОДНИМ удержанием мьютекса (RunSerializedAsync), импорт — через негейтедное ядро
+        // ApplyScanResults (релизный PR #76, P2). Проверяем именно эту связку.
+        await _service.RunSerializedAsync(async () =>
+        {
+            _service.ApplyScanResults(
+                new[]
+                {
+                    (builtin.Id, new ProfileProbeResult { Score = 90, SuccessRate = 0.9, ProcessStable = true }),
+                    (weak.Id, new ProfileProbeResult { Score = 30, SuccessRate = 0.3, ProcessStable = true }),
+                },
+                _fingerprints.Capture().Hash);
+
+            await Task.CompletedTask.ConfigureAwait(false);
+        });
+
         var deleted = await _service.PurgeWeakEvolutionsAsync();
 
         Assert.Equal(1, deleted);

--- a/FluxRoute/ViewModels/MainViewModel.Orchestrator.cs
+++ b/FluxRoute/ViewModels/MainViewModel.Orchestrator.cs
@@ -878,6 +878,12 @@ public partial class MainViewModel
                 {
                     bestProfileStarted = true;
                     await SwitchProfileAsync(bestProfile).ConfigureAwait(false);
+
+                    // Согласуем состояние ИИ под тем же удержанием мьютекса: если рабочим стал профиль
+                    // с другим генотипом, отслеживаемый генотип надо сбросить, иначе следующий цикл
+                    // проверит новый профиль, а результат запишет под старым _currentGenome.Id
+                    // (правка по Codex P1, ревью #97).
+                    _aiOrchestrator.ReconcileGenomeWithActiveProfile();
                 }
                 else if (wasRunning && SelectedProfile is not null && !IsTrackedProcessRunning())
                 {

--- a/FluxRoute/ViewModels/MainViewModel.Orchestrator.cs
+++ b/FluxRoute/ViewModels/MainViewModel.Orchestrator.cs
@@ -844,6 +844,9 @@ public partial class MainViewModel
             // циклом ИИ, выход должен идти через внешний путь отмены, а не через «успешное»
             // завершение уже отменённого скана (правка по Codex P2, ревью #97).
             var networkUnchangedAfterScan = false;
+            ProfileItem? bestProfile = null;
+            var bestScore = 0;
+            var bestProfileStarted = false;
             await _aiOrchestrator.RunSerializedAsync(async () =>
             {
                 // ═══ v1.7.1: сетевой хэш фиксируем непосредственно перед сканом, уже удерживая
@@ -862,6 +865,25 @@ public partial class MainViewModel
                 // ПРЕДЫДУЩЕГО скана — не переносим их под новым хэшем (Codex P1, 13-й раунд).
                 if (AiEnabled && !scanCt.IsCancellationRequested && networkUnchangedAfterScan)
                     PersistScanScoresIntoGenomes(scanNetworkHash);
+
+                // ═══ Финальный выбор и запуск лучшей стратегии — тоже под мьютексом:
+                // ScanAllProfilesAsync останавливает последний проверенный профиль, но оставляет его
+                // выбранным, поэтому цикл ИИ, ворвавшийся сразу после Release, проверил бы
+                // остановленный процесс и записал фейл в свой _currentGenome, а UI параллельно
+                // переключил бы профиль — состояние генотипа разошлось бы с рабочим профилем
+                // (правка по Codex P1, ревью #97).
+                bestProfile = _orchestrator.BestRankedProfile;
+                bestScore = _orchestrator.BestRankedScore;
+                if (bestProfile is not null)
+                {
+                    bestProfileStarted = true;
+                    await SwitchProfileAsync(bestProfile).ConfigureAwait(false);
+                }
+                else if (wasRunning && SelectedProfile is not null && !IsTrackedProcessRunning())
+                {
+                    bestProfileStarted = true;
+                    await EnsureProtectionRunningAsync().ConfigureAwait(false);
+                }
             }, scanCt);
 
             SortProfileScores();
@@ -893,19 +915,16 @@ public partial class MainViewModel
                 RefreshAiDashboard();
             }
 
-            var bestProfile = _orchestrator.BestRankedProfile;
-            var bestScore = _orchestrator.BestRankedScore;
+            // Профиль уже выбран и запущен внутри сериализованного блока; здесь только UI-часть:
+            // AddOrchestratorLog/Logs пишут в привязанные коллекции и должны идти с UI-потока.
             ScanBestStrategyText = bestProfile is null
                 ? "Рабочая стратегия не найдена"
                 : $"{bestProfile.DisplayName} · {bestScore}%";
-            if (bestProfile is not null)
+            if (bestProfileStarted && bestProfile is not null)
             {
                 AddOrchestratorLog($"[{DateTime.Now:HH:mm:ss}] ▶ Запуск лучшей стратегии «{bestProfile.DisplayName}» ({bestScore}%).");
                 Logs.Add($"[Оркестратор] Лучшая стратегия после сканирования: «{bestProfile.DisplayName}».");
-                await SwitchProfileAsync(bestProfile).ConfigureAwait(false);
             }
-            else if (wasRunning && SelectedProfile is not null && !IsTrackedProcessRunning())
-                await EnsureProtectionRunningAsync().ConfigureAwait(false);
 
             // Задержка перед закрытием оверлея, чтобы пользователь увидел "100% Завершено"
             await Task.Delay(800, scanCt).ConfigureAwait(false);

--- a/FluxRoute/ViewModels/MainViewModel.Orchestrator.cs
+++ b/FluxRoute/ViewModels/MainViewModel.Orchestrator.cs
@@ -886,15 +886,24 @@ public partial class MainViewModel
                 // (правка по Codex P1, ревью #97).
                 bestProfile = _orchestrator.BestRankedProfile;
                 bestScore = _orchestrator.BestRankedScore;
-                if (bestProfile is not null)
+
+                // ═══ После внешней отмены (Stop, кнопка отмены) профиль заново НЕ поднимаем:
+                // ScanAllProfilesAsync гасит OperationCanceledException внутри и возвращается штатно,
+                // поэтому без этой проверки фолбэк-ветка «защита была запущена, а процесс уже не
+                // работает» сразу стартовала бы профиль снова, отменяя явную остановку пользователя
+                // (правка по Codex P1, ревью #97).
+                if (!scanCt.IsCancellationRequested)
                 {
-                    bestProfileStarted = true;
-                    await SwitchProfileAsync(bestProfile).ConfigureAwait(false);
-                }
-                else if (wasRunning && SelectedProfile is not null && !IsTrackedProcessRunning())
-                {
-                    bestProfileStarted = true;
-                    await EnsureProtectionRunningAsync().ConfigureAwait(false);
+                    if (bestProfile is not null)
+                    {
+                        bestProfileStarted = true;
+                        await SwitchProfileAsync(bestProfile).ConfigureAwait(false);
+                    }
+                    else if (wasRunning && SelectedProfile is not null && !IsTrackedProcessRunning())
+                    {
+                        bestProfileStarted = true;
+                        await EnsureProtectionRunningAsync().ConfigureAwait(false);
+                    }
                 }
 
                 // ═══ Состояние ИИ согласуем ПОД ТЕМ ЖЕ удержанием мьютекса и во всех случаях: рабочим
@@ -904,6 +913,12 @@ public partial class MainViewModel
                 // следующий цикл проверит новый профиль, а результат запишет под чужим Id — порча
                 // истории и состояния бандита (правка по Codex P1, ревью #97).
                 _aiOrchestrator.ReconcileGenomeWithActiveProfile();
+
+                // ═══ Выход через внешний путь отмены, а не через успешное завершение: иначе отменённый
+                // скан перезаписал бы статус («Сканирование завершено»), сохранил настройки и обновил
+                // ИИ-строки как по полноценному прогону. Согласование генотипа выше уже выполнено —
+                // скан мог успеть переключить профиль до отмены (правка по Codex P1, ревью #97).
+                scanCt.ThrowIfCancellationRequested();
             }, scanCt);
 
             SortProfileScores();

--- a/FluxRoute/ViewModels/MainViewModel.Orchestrator.cs
+++ b/FluxRoute/ViewModels/MainViewModel.Orchestrator.cs
@@ -438,7 +438,7 @@ public partial class MainViewModel
     /// проверки, чтобы вкладка ИИ и очистка/подбор видели фактические значения.
     /// Не перезапускает стратегии. <paramref name="networkHash"/> — хэш сети ДО начала скана.
     /// </summary>
-    private async Task PersistScanScoresIntoGenomes(string networkHash)
+    private void PersistScanScoresIntoGenomes(string networkHash)
     {
         try
         {
@@ -456,7 +456,10 @@ public partial class MainViewModel
                 results.Add((g.Id, entry.result));
             }
 
-            await _aiOrchestrator.PersistScanVerification(results, networkHash).ConfigureAwait(true);
+            // Мьютекс уже удерживает вызывающий (весь скан-и-импорт атомарен относительно циклов
+            // ИИ — релизный PR #76, P2), поэтому вызываем ядро импорта БЕЗ повторного захвата:
+            // SemaphoreSlim не реентерабелен, вложенный захват привёл бы к дедлоку.
+            _aiOrchestrator.ApplyScanResults(results, networkHash);
         }
         catch (Exception ex)
         {
@@ -834,7 +837,28 @@ public partial class MainViewModel
             // ═══ v1.7.1: фиксируем сетевой хэш ДО начала скана — если сеть сменится в процессе,
             // результаты не будут помечены новым (а не фактическим) хэшем (правка Codex P1, пятый раунд).
             var scanNetworkHash = _aiFingerprints.Capture().Hash;
-            await _orchestrator.ScanAllProfilesAsync(scanCt, progress, checkProgress);
+
+            // ═══ Полный скан и импорт его результатов в генотипы ИИ — под ОДНИМ удержанием
+            // мьютекса с фоновыми циклами ИИ. Иначе RunCycleAsync успевал бы переключать/пробовать
+            // профили, пока скан их измеряет, и в bandit/историю попадали бы баллы за уже нарушенные
+            // профили. Сериализовать только запись мало — сериализуется весь скан-и-импорт
+            // (правка по Codex, релизный PR #76, P2).
+            var networkUnchangedAfterScan = false;
+            await _aiOrchestrator.RunSerializedAsync(async () =>
+            {
+                await _orchestrator.ScanAllProfilesAsync(scanCt, progress, checkProgress).ConfigureAwait(true);
+
+                // Если сеть сменилась за время скана — результаты относятся к разным сетям и не
+                // должны быть помечены одним хэшем (правка по Codex P1, восьмой раунд).
+                networkUnchangedAfterScan = string.Equals(_aiFingerprints.Capture().Hash, scanNetworkHash, StringComparison.Ordinal);
+
+                // Импорт идёт сразу, в том же удержании мьютекса — окна для цикла между измерением
+                // и записью нет. При отмене скана LastScanResults может содержать результаты
+                // ПРЕДЫДУЩЕГО скана — не переносим их под новым хэшем (Codex P1, 13-й раунд).
+                if (AiEnabled && !scanCt.IsCancellationRequested && networkUnchangedAfterScan)
+                    PersistScanScoresIntoGenomes(scanNetworkHash);
+            });
+
             SortProfileScores();
             RebuildPassedScanProfiles();
             UpdateScanBestStrategyText();
@@ -851,24 +875,14 @@ public partial class MainViewModel
             // готовые результаты в генотипы БЕЗ повторного запуска стратегий (правка по Codex P2).
             if (AiEnabled)
             {
-                // При отмене скана ScanAllProfilesAsync возвращается штатно, а LastScanResults
-                // может содержать результаты ПРЕДЫДУЩЕГО завершённого скана — не переносим их
-                // под новым хэшем (правка по Codex P1, тринадцатый раунд).
-                if (!scanCt.IsCancellationRequested)
+                // Скан и импорт уже выполнены в одном удержании мьютекса выше; здесь остаётся
+                // только предупредить, если сеть сменилась и результаты сознательно не сохранены
+                // (правка по Codex P1, восьмой раунд).
+                if (!scanCt.IsCancellationRequested && !networkUnchangedAfterScan)
                 {
-                    // Если сеть сменилась за время скана — результаты относятся к разным сетям и не
-                    // должны быть помечены одним хэшем: иначе bandit/очистка получили бы наблюдения
-                    // от чужой сети (правка по Codex P1, восьмой раунд). В этом случае не переносим.
-                    if (string.Equals(_aiFingerprints.Capture().Hash, scanNetworkHash, StringComparison.Ordinal))
-                    {
-                        await PersistScanScoresIntoGenomes(scanNetworkHash);
-                    }
-                    else
-                    {
-                        var msg = "Сеть изменилась во время сканирования — результаты не сохранены.";
-                        AddOrchestratorLog($"[{DateTime.Now:HH:mm:ss}] ⚠️ {msg}");
-                        Logs.Add($"[ИИ] {msg}");
-                    }
+                    var msg = "Сеть изменилась во время сканирования — результаты не сохранены.";
+                    AddOrchestratorLog($"[{DateTime.Now:HH:mm:ss}] ⚠️ {msg}");
+                    Logs.Add($"[ИИ] {msg}");
                 }
                 RebuildAiStrategyRows();
                 RefreshAiDashboard();

--- a/FluxRoute/ViewModels/MainViewModel.Orchestrator.cs
+++ b/FluxRoute/ViewModels/MainViewModel.Orchestrator.cs
@@ -878,18 +878,20 @@ public partial class MainViewModel
                 {
                     bestProfileStarted = true;
                     await SwitchProfileAsync(bestProfile).ConfigureAwait(false);
-
-                    // Согласуем состояние ИИ под тем же удержанием мьютекса: если рабочим стал профиль
-                    // с другим генотипом, отслеживаемый генотип надо сбросить, иначе следующий цикл
-                    // проверит новый профиль, а результат запишет под старым _currentGenome.Id
-                    // (правка по Codex P1, ревью #97).
-                    _aiOrchestrator.ReconcileGenomeWithActiveProfile();
                 }
                 else if (wasRunning && SelectedProfile is not null && !IsTrackedProcessRunning())
                 {
                     bestProfileStarted = true;
                     await EnsureProtectionRunningAsync().ConfigureAwait(false);
                 }
+
+                // ═══ Состояние ИИ согласуем ПОД ТЕМ ЖЕ удержанием мьютекса и во всех случаях: рабочим
+                // становится либо лучший профиль скана, либо последний проверенный (фолбэк, когда ни
+                // один профиль не набрал очков), а скан в любом случае оставляет выбранным последний
+                // проверенный профиль. Если отслеживаемый генотип остался от прежнего профиля,
+                // следующий цикл проверит новый профиль, а результат запишет под чужим Id — порча
+                // истории и состояния бандита (правка по Codex P1, ревью #97).
+                _aiOrchestrator.ReconcileGenomeWithActiveProfile();
             }, scanCt);
 
             SortProfileScores();

--- a/FluxRoute/ViewModels/MainViewModel.Orchestrator.cs
+++ b/FluxRoute/ViewModels/MainViewModel.Orchestrator.cs
@@ -834,18 +834,23 @@ public partial class MainViewModel
         try
         {
             _suppressOrchestratorStop = true;
-            // ═══ v1.7.1: фиксируем сетевой хэш ДО начала скана — если сеть сменится в процессе,
-            // результаты не будут помечены новым (а не фактическим) хэшем (правка Codex P1, пятый раунд).
-            var scanNetworkHash = _aiFingerprints.Capture().Hash;
 
             // ═══ Полный скан и импорт его результатов в генотипы ИИ — под ОДНИМ удержанием
             // мьютекса с фоновыми циклами ИИ. Иначе RunCycleAsync успевал бы переключать/пробовать
             // профили, пока скан их измеряет, и в bandit/историю попадали бы баллы за уже нарушенные
             // профили. Сериализовать только запись мало — сериализуется весь скан-и-импорт
             // (правка по Codex, релизный PR #76, P2).
+            // scanCt передаётся и в ожидание мьютекса: если скан отменят, пока он стоит в очереди за
+            // циклом ИИ, выход должен идти через внешний путь отмены, а не через «успешное»
+            // завершение уже отменённого скана (правка по Codex P2, ревью #97).
             var networkUnchangedAfterScan = false;
             await _aiOrchestrator.RunSerializedAsync(async () =>
             {
+                // ═══ v1.7.1: сетевой хэш фиксируем непосредственно перед сканом, уже удерживая
+                // мьютекс, — тогда два замера ограничивают сам скан, а не время ожидания в очереди
+                // за циклом ИИ (правка по Codex P2, ревью #97; ранее — P1, пятый раунд).
+                var scanNetworkHash = _aiFingerprints.Capture().Hash;
+
                 await _orchestrator.ScanAllProfilesAsync(scanCt, progress, checkProgress).ConfigureAwait(true);
 
                 // Если сеть сменилась за время скана — результаты относятся к разным сетям и не
@@ -857,7 +862,7 @@ public partial class MainViewModel
                 // ПРЕДЫДУЩЕГО скана — не переносим их под новым хэшем (Codex P1, 13-й раунд).
                 if (AiEnabled && !scanCt.IsCancellationRequested && networkUnchangedAfterScan)
                     PersistScanScoresIntoGenomes(scanNetworkHash);
-            });
+            }, scanCt);
 
             SortProfileScores();
             RebuildPassedScanProfiles();

--- a/FluxRoute/ViewModels/MainViewModel.Orchestrator.cs
+++ b/FluxRoute/ViewModels/MainViewModel.Orchestrator.cs
@@ -707,8 +707,13 @@ public partial class MainViewModel
         _scanCts = null;
         _scanEtaTimer?.Stop();
         _scanEtaTimer = null;
-        // Инвалидируем поколение — старый finally увидит gen != _scanGeneration и не тронет IsScanning
+        // Инвалидируем поколение — старый finally увидит gen != _scanGeneration и не тронет IsScanning.
+        // Флаг подавления остановки снимаем прямо здесь: иначе после отмены скана «снаружи»
+        // (остановка защиты) его finally уже не выполнит свою ветку и флаг остался бы включённым
+        // навсегда — кнопка Stop больше не останавливала бы сервисы оркестратора
+        // (правка по Codex P2, ревью #97).
         _scanGeneration++;
+        _suppressOrchestratorStop = false;
         IsScanning = false;
         GlobalOverlayVisible = false;
         OnPropertyChanged(nameof(CanCancelScan));
@@ -833,7 +838,16 @@ public partial class MainViewModel
 
         try
         {
-            _suppressOrchestratorStop = true;
+            // ═══ Флаг подавления остановки ставится ВНУТРИ сериализованного блока, уже после захвата
+            // мьютекса. Ожидание в очереди за долгим циклом ИИ — это ещё не скан, и если пользователь
+            // жмёт Stop в этот момент, остановка сервисов оркестратора должна пройти штатно, а не быть
+            // подавлена: иначе процесс убит, а сервисы ИИ живы, и вставший из очереди скан снова
+            // поднял бы профили после явной остановки защиты (правка по Codex P2, ревью #97).
+            // Поднятый ранее скан снимается отменой в StopOrchestratorServices.
+            var networkUnchangedAfterScan = false;
+            ProfileItem? bestProfile = null;
+            var bestScore = 0;
+            var bestProfileStarted = false;
 
             // ═══ Полный скан и импорт его результатов в генотипы ИИ — под ОДНИМ удержанием
             // мьютекса с фоновыми циклами ИИ. Иначе RunCycleAsync успевал бы переключать/пробовать
@@ -843,12 +857,10 @@ public partial class MainViewModel
             // scanCt передаётся и в ожидание мьютекса: если скан отменят, пока он стоит в очереди за
             // циклом ИИ, выход должен идти через внешний путь отмены, а не через «успешное»
             // завершение уже отменённого скана (правка по Codex P2, ревью #97).
-            var networkUnchangedAfterScan = false;
-            ProfileItem? bestProfile = null;
-            var bestScore = 0;
-            var bestProfileStarted = false;
             await _aiOrchestrator.RunSerializedAsync(async () =>
             {
+                _suppressOrchestratorStop = true;
+
                 // ═══ v1.7.1: сетевой хэш фиксируем непосредственно перед сканом, уже удерживая
                 // мьютекс, — тогда два замера ограничивают сам скан, а не время ожидания в очереди
                 // за циклом ИИ (правка по Codex P2, ревью #97; ранее — P1, пятый раунд).
@@ -1048,7 +1060,12 @@ public partial class MainViewModel
     // ── Остановка сервисов оркестратора без изменения флага OrchestratorEnabled ──
     private void StopOrchestratorServices()
     {
-        if (_orchestratorStartInProgress && IsScanning)
+        // ═══ Скан оркестратора держит мьютекс ИИ и после остановки сервисов поднял бы профили заново,
+        // поэтому снимаем и выполняющийся скан, и стоящий в очереди за циклом ИИ. Прежнее условие
+        // (_orchestratorStartInProgress) не покрывало скан, запущенный кнопкой: нажатие Stop убивало
+        // процесс, но скан оставался жив и после отпускания мьютекса снова стартовал профили
+        // (правка по Codex P2, ревью #97).
+        if (IsScanning)
             CancelScan();
 
         if (!_orchestrator.IsRunning && !_aiOrchestrator.IsRunning)


### PR DESCRIPTION
## Цель

Закрыть замечания Codex по релизному PR [#76](https://github.com/klondike0x/FluxRoute/pull/76): сериализовать **полный скан** с импортом его результатов и согласовать состояние ИИ с профилем, который скан реально запустил (issue [#89](https://github.com/klondike0x/FluxRoute/issues/89)).

## Причина

Мьютекс `_aiGate` брался только на записи результатов (`PersistScanVerification`), тогда как сам скан (`_orchestrator.ScanAllProfilesAsync`) и запуск выбранной стратегии шли без него. Фоновый `RunCycleAsync` мог переключать/пробовать профили, пока скан их измеряет, — и в историю/bandit попадали баллы за уже нарушенные профили.

## Изменено

- **`FluxRoute.AI/Services/AiOrchestratorService.cs`**
  - `PersistScanVerification` разделён на gated-обёртку (мьютекс + делегирование) и негейтедное ядро `ApplyScanResults` — вложенный захват `SemaphoreSlim` недопустим (не реентерабелен, был бы дедлок).
  - Добавлена перегрузка `RunSerializedAsync(Func<Task>, CancellationToken)` для операций без результата; отмена проходит через ожидание гейта.
  - `GenomeMatchesProfile` приведён к каноническому сопоставлению «генотип ↔ профиль»: при известном с обеих сторон пути решает только путь с нормализацией разделителей, регистра и хвостового разделителя. Одноимённые встроенный и ai-evolved BAT — разные стратегии, а `LoadProfiles` при коллизии имён отдаёт предпочтение evolved-пути.
  - `ReconcileGenomeWithActiveProfile()` — согласование отслеживаемого генотипа с рабочим профилем (внешняя смена профиля сканом) и обнуление серии неудач вместе с генотипом, как в обычной ветке смены стратегии.
  - `ResolveProfile`, `FindGenomeForProfile`, `ReconcileGenomeWithActiveProfile` подтягивают устаревший путь BAT (`RefreshStaleBatPath`/`StoreBatPath`): при переезде портативной установки в реестре остаётся прежний абсолютный путь, и без этого свой же evolved-генотип считался чужим. Лечение — только для эволюционированных стратегий, чтобы встроенный генотип не «усыновил» одноимённый evolved-BAT.
  - `RefreshStaleBatPath` каноническим считает **текущую** `engine\ai-evolved`: путь из реестра используется лишь как резерв, когда файла в текущей установке нет (копия старой папки не должна закреплять генотип за прошлой установкой). `ResolveProfile` освежает путь перед выбором BAT.
  - Флаг `_suppressOrchestratorStop` ставится внутри сериализованного блока — после захвата мьютекса; `StopOrchestratorServices` снимает любой активный скан, а `CancelScan` сбрасывает флаг подавления.
  - `FindExistingBatPath` ищет BAT по происхождению генотипа: встроенная стратегия — в корне `engine`, эволюционированная — в `engine\ai-evolved`; материализация из полей (`WriteBat`) — только для эволюционированных. Раньше встроенному генотипу с отсутствующим файлом подставлялся одноимённый evolved-BAT, и его путь закреплялся за встроенным генотипом.
- **`FluxRoute/ViewModels/MainViewModel.Orchestrator.cs`**
  - `ScanAllProfilesAsync` и импорт результатов обёрнуты в один `RunSerializedAsync`: сериализуется весь скан-и-импорт, окна для цикла между измерением и записью нет.
  - Замер сети выполняется внутри гейта (уже по актуальному состоянию); проверка «сеть не сменилась» и предупреждение о смене сети сохранены.
  - Выбор и запуск лучшей стратегии — внутри того же удержания мьютекса; там же согласование генотипа (в том числе в фолбэк-ветке, когда ни один профиль не набрал очков).
  - После отмены скана (Stop или кнопка отмены) запуск лучшей стратегии и фолбэк-ветка не выполняются, а выход из сериализованного блока идёт через путь отмены: `ScanAllProfilesAsync` гасит `OperationCanceledException` внутри, поэтому без этой проверки профиль поднимался бы заново сразу после явной остановки, а статус переписывался бы на «Сканирование завершено». Согласование генотипа остаётся безусловным — скан мог успеть переключить профиль до отмены.
  - `PersistScanScoresIntoGenomes` вызывает ядро `ApplyScanResults` без повторного захвата мьютекса.
  - Журнальные записи (`AddOrchestratorLog`, `Logs`) остаются на UI-потоке — они пишут в привязанные `ObservableCollection`.
- **`FluxRoute.AI/FluxRoute.AI.csproj`** — `InternalsVisibleTo` для тестов: доступ к отслеживаемому генотипу и серии неудач, чтобы проверять согласование.

## Убрано

- Повторный (вложенный) захват `_aiGate` из `PersistScanScoresIntoGenomes`.
- Дублирование признака сопоставления профиля и генотипа в `FindGenomeForProfile` — используется общий `GenomeMatchesProfile`.

## Тесты

- `ApplyScanResults_UnderSerializedScanGate_RecordsOutcome_SoPurgeFindsCandidate` — production-связка «скан-и-импорт под `RunSerializedAsync`».
- `AiOrchestratorBatPathTests` — поиск BAT по происхождению генотипа: сохранённый путь, корень `engine` для встроенных, `ai-evolved` для эволюционированных, отказ подставлять одноимённый evolved-BAT встроенному генотипу.
- `AiOrchestratorGenomeReconcileTests` — сопоставление по BAT/имени/пути, различение одноимённых built-in и ai-evolved BAT, нормализация пути, сохранение и сброс генотипа, обнуление серии неудач, отсутствие активного профиля, подтягивание устаревшего пути при переезде установки и отказ «усыновлять» evolved-BAT встроенным генотипом, приоритет текущей `engine\ai-evolved` над живой копией старой установки.
- В `PersistScanVerification_...` добавлен `await` (сборка давала `CS4014`, а без ожидания purge мог обогнать импорт — тест был бы флаки).

## Проверка

- `dotnet build FluxRoute.slnx` — успешно; предупреждений от правок нет.
- `dotnet test FluxRoute.slnx -c Debug` — **380/380**, ошибок нет.

## Связанные PR

- Релизный PR [release: FluxRoute v1.7.1 — фикс-релиз #76](https://github.com/klondike0x/FluxRoute/pull/76) (nightly → master, v1.7.1).
- [fix(ai): сериализовать импорт результатов скана с циклами ИИ #95](https://github.com/klondike0x/FluxRoute/pull/95) и [fix(ai): сериализовать целевую эволюцию с очисткой #96](https://github.com/klondike0x/FluxRoute/pull/96).

## Тикет

- issue [Непонятная работа кнопок оркестратора. #89](https://github.com/klondike0x/FluxRoute/issues/89).